### PR TITLE
Fix permissions of the frontend image to make it work in Openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,14 @@ FROM ruby:2.5.1
 RUN apt-get update -qq && \
   apt-get install -y build-essential libpq-dev && \
   curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
-RUN mkdir /spree
+COPY . /spree
 WORKDIR /spree
-ADD . /spree
 RUN bundle install
 RUN bundle update sassc && bundle exec rake sandbox
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 COPY ./sandbox /spree/sandbox
+RUN cd sandbox && bundle update sassc
+WORKDIR /spree
+RUN chgrp -R 0 /spree && \
+    chmod -R g=u /spree
 CMD ["sh", "docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This is entrypoint for docker image of spree sandbox on docker cloud
 
-RAILS_ENV=production cd sandbox && bundle update sassc && bundle exec rails s -p 3000 -b '0.0.0.0'
+RAILS_ENV=production cd sandbox && bundle exec rails s -p 3000 -b '0.0.0.0'


### PR DESCRIPTION
This PR improves the Dockerfile for the frontend service in two ways to make it run correctly in Openshift with a restricted SCC:

* It avoids running `bundle update sassc` inside the entrypoint, as in Openshift that will be run as non-root and will fail.
* As, by default, every user in K8s will be part of the root (0) group, it sets group write permissions to the root group in the `/spree` folder, to be able to run changes there by the user that ends up owning the container