### PR TITLE
Remove hardcoded datadog agent name in the Rails app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
       - DATADOG_SERVICE_NAME=discounts-service
-      - DATADOG_TRACE_AGENT_HOSTNAME=agent
+      - DD_AGENT_HOST=agent
       - DD_LOGS_INJECTION=true
       - DD_ANALYTICS_ENABLED=true
     image: "burningion/ecommerce-spree-discounts:latest"
@@ -40,7 +40,7 @@ services:
       com.datadoghq.ad.logs: '[{"source": "python", "service": "discounts-service"}]'
   frontend:
     environment:
-      - DATADOG_TRACE_AGENT_HOSTNAME=agent
+      - DD_AGENT_HOST=agent
       - DD_LOGS_INJECTION=true
       - DD_ANALYTICS_ENABLED=true
       - DB_USERNAME
@@ -65,7 +65,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
       - DATADOG_SERVICE_NAME=advertisements-service
-      - DATADOG_TRACE_AGENT_HOSTNAME=agent
+      - DD_AGENT_HOST=agent
       - DD_LOGS_INJECTION=true
       - DD_ANALYTICS_ENABLED=true
     image: "burningion/ecommerce-spree-ads:latest"

--- a/store-frontend/config/initializers/datadog.rb
+++ b/store-frontend/config/initializers/datadog.rb
@@ -3,5 +3,4 @@ Datadog.configure do |c|
   c.use :rails, {'analytics_enabled': true, 'service_name': 'store-frontend', 'cache_service': 'store-frontend-cache', 'database_service': 'store-frontend-sqlite'}
   # Make sure requests are also instrumented
   c.use :http, {'analytics_enabled': true, 'service_name': 'store-frontend'}
-  c.tracer hostname: 'agent'
 end


### PR DESCRIPTION
This removes the hardcoded datadog agent name from the Rails app.

In Kubernetes, to connect to the trace agent you need to set up the downwardAPI, so connecting to a service called `agent` doesn't work.

Also, to avoid breaking the Rails tracing in the docker-compose environment, move to the documented `DD_AGENT_HOST` env variable to set the agent hostname.