### PR TITLE
Deploy eCommerce to Google Cloud

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,0 +1,83 @@
+# Deploy eCommerce Application in Google Cloud
+
+This set of Terraform files deploys the eCommerce application into Google Cloud.
+
+## Pre-Requisites
+
+1. Google Cloud Platform account
+1. [HashiCorp Terraform 0.12+](https://www.terraform.io/downloads.html)
+1. Datadog API Key (for Agent)
+
+## Create the instance
+
+The instance contains the eCommerce application with all of its services running
+in containers. After it creates the services with `docker-compose`, the instance
+will start `goreplay` to automatically generate traffic to store-frontend.
+
+Set the following environment variables.
+
+```shell
+> export TF_VAR_dd_api_key=<datadog api key for agent container>
+> export GOOGLE_PROJECT=<google cloud project to deploy>
+```
+
+Authenticate to Google Cloud.
+
+```shell
+> gcloud auth login
+```
+
+Initialize Terraform. This retrieves the Google Cloud Provider. By [initializing
+locally](https://www.terraform.io/docs/state/index.html), your state file will
+not be backed up! If you delete the state file, you will have an instance
+running in Google Cloud that will need to manually be removed.
+
+```shell
+> terraform init
+```
+
+Next, apply the command. It will output a dry run that will let you know the
+changes that will be executed to the instance.
+
+```shell
+> terraform plan
+...
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value:
+```
+
+Type "yes" to execute the changes to the instance.
+
+After Terraform executes, you will see an instance in the Google Cloud console
+called `datadog-ecommerce`. By default, the configuration will create a firewall
+rule to enable traffic to port 3000. You can access the public endpoint for the
+ecommerce application by retrieving it from Terraform output.
+
+> Note: Even after Terraform finishes applying, it will take 3-5 minutes for the
+> instance to be ready and its public endpoint to be accessible. This is because
+> the startup script installs every package, starts up each container, and
+> connects to Datadog.
+
+```shell
+> open http://$(terraform output public_ip):3000
+```
+
+## Delete the instance
+
+Check if you have a `terraform.tfstate` file locally. If you do not, you must
+delete the instance manually in the Google Cloud console.
+
+```shell
+> ls terraform.tfstate
+```
+
+Otherwise, execute Terraform to destroy the instance and its public IP address.
+
+```shell
+> terraform destroy -auto-approve
+```

--- a/gcp/instance.tf
+++ b/gcp/instance.tf
@@ -1,0 +1,83 @@
+resource "google_compute_instance" "ecommerce" {
+  name         = var.name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  tags = ["datadog", "ecommerce"]
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-1804-lts"
+    }
+  }
+
+  network_interface {
+    network = var.network_name
+
+    access_config {
+      nat_ip = google_compute_address.ecommerce.address
+    }
+  }
+
+  metadata = {
+    owner       = "datadog"
+    application = "ecommerce"
+  }
+
+  metadata_startup_script = <<EOT
+  #!/bin/bash
+  set -e
+
+  timeout 180 /bin/bash -c \
+    'until stat /var/lib/cloud/instance/boot-finished 2>/dev/null; do echo waiting ...; sleep 1; done'
+
+  echo "[Unit]
+Description=GOR for Datadog
+After=local-fs.target network-online.target network.target rsyslog.service
+After=google-instance-setup.service google-network-setup.service
+Wants=local-fs.target network-online.target network.target
+
+[Service]
+WorkingDirectory=/root/ecommerce-workshop
+ExecStart=/usr/local/bin/gor --input-file-loop --input-file requests_0.gor --output-http http://localhost:3000
+KillMode=process
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+" > /lib/systemd/system/gor.service
+  
+  export DEBIAN_FRONTEND=noninteractive
+
+  apt-get -y install apt-transport-https ca-certificates curl software-properties-common
+
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
+
+  apt-get update
+
+  apt-get -y install docker-ce
+
+  curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+
+  apt-get -y install git wget
+
+  mkdir /root/ecommerce-workshop
+
+  git clone https://github.com/DataDog/ecommerce-workshop.git  /root/ecommerce-workshop
+
+  curl -L https://github.com/buger/goreplay/releases/download/v1.0.0/gor_1.0.0_x64.tar.gz -o gor_1.0.0_x64.tar.gz
+  tar -xf gor_1.0.0_x64.tar.gz
+  mv gor /usr/local/bin/gor
+  rm -rf gor_1.0.0_x64.tar.gz
+
+  POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres DD_API_KEY=${var.dd_api_key} docker-compose -f /root/ecommerce-workshop/docker-compose-files/${var.docker_compose_file}.yml up -d
+  systemctl start gor
+  EOT
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = "~>0.12"
+}
+
+provider "google" {
+  version = "~> 3.18"
+  zone    = var.zone
+}

--- a/gcp/network.tf
+++ b/gcp/network.tf
@@ -1,0 +1,14 @@
+resource "google_compute_firewall" "ecommerce" {
+  count   = var.enable_firewall_rule ? 1 : 0
+  name    = "allow-ecommerce"
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3000"]
+  }
+}
+
+resource "google_compute_address" "ecommerce" {
+  name = var.name
+}

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip" {
+  value = google_compute_instance.ecommerce.network_interface.0.access_config.0.nat_ip
+}

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -1,0 +1,40 @@
+variable "dd_api_key" {
+  type        = string
+  description = "Datadog Agent API key"
+}
+
+variable "name" {
+  type        = string
+  description = "name of instance. default is datadog-ecommerce"
+  default     = "datadog-ecommerce"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "size of instance. default is n1-standard-2"
+  default     = "n1-standard-2"
+}
+
+variable "network_name" {
+  type        = string
+  description = "gcp network name. default is default"
+  default     = "default"
+}
+
+variable "zone" {
+  type        = string
+  description = "gcp zone to deploy"
+  default     = "us-east1-b"
+}
+
+variable "enable_firewall_rule" {
+  type        = bool
+  description = "creates firewall rule to allow public traffic"
+  default     = true
+}
+
+variable "docker_compose_file" {
+  type        = string
+  description = "docker-compose file to deploy. defaults to docker-compose-fixed-instrumented"
+  default     = "docker-compose-fixed-instrumented"
+}


### PR DESCRIPTION
This pull request contains code to deploy the ecommerce application to Google Cloud (GCP). It uses the existing `docker-compose` files to start up application containers on a single GCP instance, automatically initialize `goreplay` to generate traffic, and sends metrics to Datadog. The GCP compute instance is accessible by default via a public IP.

Initially created as part of a webinar and requested by @burningion. 