### PR TITLE
Add example ECS task roles and fix hardcoded Agent hostname

### DIFF
--- a/aws/agent-task.json
+++ b/aws/agent-task.json
@@ -1,0 +1,173 @@
+{
+    "ipcMode": null,
+    "executionRoleArn": "<YOUR TASK EXECUTION ROLE ARN HERE>",
+    "containerDefinitions": [
+        {
+            "dnsSearchDomains": null,
+            "logConfiguration": null,
+            "entryPoint": null,
+            "portMappings": [
+                {
+                    "hostPort": 8126,
+                    "protocol": "tcp",
+                    "containerPort": 8126
+                },
+                {
+                    "hostPort": 8125,
+                    "protocol": "tcp",
+                    "containerPort": 8125
+                }
+            ],
+            "command": null,
+            "linuxParameters": null,
+            "cpu": 10,
+            "environment": [
+                {
+                    "name": "DD_ECS_COLLECT_RESOURCE_TAGS_EC2",
+                    "value": "true"
+                },
+                {
+                    "name": "SD_BACKEND",
+                    "value": "docker"
+                },
+                {
+                    "name": "DD_APM_NON_LOCAL_TRAFFIC",
+                    "value": "true"
+                },
+                {
+                    "name": "DD_API_KEY",
+                    "value": "<INSERT YOUR API KEY HERE>"
+                },
+                {
+                    "name": "DD_PROCESS_AGENT_ENABLED",
+                    "value": "true"
+                },
+                {
+                    "name": "DD_APM_ENABLED",
+                    "value": "true"
+                },
+                {
+                    "name": "DD_LOGS_ENABLED",
+                    "value": "true"
+                },
+                {
+                    "name": "DD_TAGS",
+                    "value": "'env:ruby-shop'"
+                },
+                {
+                    "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+                    "value": "true"
+                },
+                {
+                    "name": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC",
+                    "value": "true"
+                }
+            ],
+            "resourceRequirements": null,
+            "ulimits": null,
+            "dnsServers": null,
+            "mountPoints": [
+                {
+                    "readOnly": true,
+                    "containerPath": "/var/run/docker.sock",
+                    "sourceVolume": "docker_sock"
+                },
+                {
+                    "readOnly": true,
+                    "containerPath": "/host/sys/fs/cgroup",
+                    "sourceVolume": "cgroup"
+                },
+                {
+                    "readOnly": true,
+                    "containerPath": "/host/proc",
+                    "sourceVolume": "proc"
+                },
+                {
+                    "readOnly": false,
+                    "containerPath": "/opt/datadog-agent/run",
+                    "sourceVolume": "pointdir"
+                }
+            ],
+            "workingDirectory": null,
+            "secrets": null,
+            "dockerSecurityOptions": null,
+            "memory": 256,
+            "memoryReservation": null,
+            "volumesFrom": [],
+            "stopTimeout": null,
+            "image": "datadog/agent:latest",
+            "startTimeout": null,
+            "firelensConfiguration": null,
+            "dependsOn": null,
+            "disableNetworking": null,
+            "interactive": null,
+            "healthCheck": null,
+            "essential": true,
+            "links": null,
+            "hostname": null,
+            "extraHosts": null,
+            "pseudoTerminal": null,
+            "user": null,
+            "readonlyRootFilesystem": null,
+            "dockerLabels": null,
+            "systemControls": null,
+            "privileged": null,
+            "name": "datadog-agent"
+        }
+    ],
+    "memory": null,
+    "taskRoleArn": "<INSERT YOUR TASK ROLE ARN HERE>",
+    "family": "datadog-agent-task",
+    "pidMode": null,
+    "requiresCompatibilities": [
+        "EC2"
+    ],
+    "networkMode": "bridge",
+    "cpu": null,
+    "inferenceAccelerators": [],
+    "proxyConfiguration": null,
+    "volumes": [
+        {
+            "efsVolumeConfiguration": null,
+            "name": "docker_sock",
+            "host": {
+                "sourcePath": "/var/run/docker.sock"
+            },
+            "dockerVolumeConfiguration": null
+        },
+        {
+            "efsVolumeConfiguration": null,
+            "name": "proc",
+            "host": {
+                "sourcePath": "/proc/"
+            },
+            "dockerVolumeConfiguration": null
+        },
+        {
+            "efsVolumeConfiguration": null,
+            "name": "cgroup",
+            "host": {
+                "sourcePath": "/cgroup/"
+            },
+            "dockerVolumeConfiguration": null
+        },
+        {
+            "efsVolumeConfiguration": null,
+            "name": "passwd",
+            "host": {
+                "sourcePath": "/etc/passwd"
+            },
+            "dockerVolumeConfiguration": null
+        },
+        {
+            "efsVolumeConfiguration": null,
+            "name": "pointdir",
+            "host": {
+                "sourcePath": "/opt/datadog-agent/run"
+            },
+            "dockerVolumeConfiguration": null
+        }
+    ],
+    "placementConstraints": [],
+    "tags": []
+}

--- a/aws/shop-task.json
+++ b/aws/shop-task.json
@@ -1,0 +1,319 @@
+{
+    "ipcMode": null,
+    "executionRoleArn": null,
+    "containerDefinitions": [
+      {
+        "dnsSearchDomains": null,
+        "logConfiguration": null,
+        "entryPoint": [],
+        "portMappings": [
+          {
+            "hostPort": 3000,
+            "protocol": "tcp",
+            "containerPort": 3000
+          }
+        ],
+        "command": [
+          "sh",
+          "docker-entrypoint.sh"
+        ],
+        "linuxParameters": null,
+        "cpu": 0,
+        "environment": [
+          {
+            "name": "DB_PASSWORD",
+            "value": "<YOUR PASSWORD>"
+          },
+          {
+            "name": "DB_USERNAME",
+            "value": "postgres"
+          },
+          {
+            "name": "DD_AGENT_HOST",
+            "value": "<PRIVATE IP OF THE EC2 INSTANCE>"
+          },
+          {
+            "name": "DD_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_APM_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_ENV",
+            "value": "ruby-shop"
+          },
+          {
+            "name": "DD_LOGS_INJECTION",
+            "value": "true"
+          }
+        ],
+        "resourceRequirements": null,
+        "ulimits": null,
+        "dnsServers": null,
+        "mountPoints": [],
+        "workingDirectory": null,
+        "secrets": null,
+        "dockerSecurityOptions": null,
+        "memory": 512,
+        "memoryReservation": null,
+        "volumesFrom": [],
+        "stopTimeout": null,
+        "image": "burningion/ecommerce-spree-observability:aws-ecs-broken-1",
+        "startTimeout": null,
+        "firelensConfiguration": null,
+        "dependsOn": null,
+        "disableNetworking": null,
+        "interactive": null,
+        "healthCheck": null,
+        "essential": true,
+        "links": [
+          "db",
+          "discounts",
+          "advertisements"
+        ],
+        "hostname": null,
+        "extraHosts": null,
+        "pseudoTerminal": null,
+        "user": null,
+        "readonlyRootFilesystem": null,
+        "dockerLabels": null,
+        "systemControls": null,
+        "privileged": null,
+        "name": "frontend"
+      },
+      {
+        "dnsSearchDomains": null,
+        "logConfiguration": null,
+        "entryPoint": null,
+        "portMappings": [
+          {
+            "hostPort": 5001,
+            "protocol": "tcp",
+            "containerPort": 5001
+          }
+        ],
+        "command": [
+          "ddtrace-run",
+          "flask",
+          "run",
+          "--port=5001",
+          "--host=0.0.0.0"
+        ],
+        "linuxParameters": null,
+        "cpu": 0,
+        "environment": [
+          {
+            "name": "DATADOG_SERVICE_NAME",
+            "value": "discounts-service"
+          },
+          {
+            "name": "DD_AGENT_HOST",
+            "value": "<PRIVATE IP OF THE EC2 INSTANCE>"
+          },
+          {
+            "name": "DD_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_LOGS_INJECTION",
+            "value": "true"
+          },
+          {
+            "name": "FLASK_APP",
+            "value": "discounts.py"
+          },
+          {
+            "name": "POSTGRES_PASSWORD",
+            "value": "<YOUR PASSWORD>"
+          },
+          {
+            "name": "POSTGRES_USER",
+            "value": "postgres"
+          }
+        ],
+        "resourceRequirements": null,
+        "ulimits": null,
+        "dnsServers": null,
+        "mountPoints": [],
+        "workingDirectory": null,
+        "secrets": null,
+        "dockerSecurityOptions": null,
+        "memory": null,
+        "memoryReservation": null,
+        "volumesFrom": [],
+        "stopTimeout": null,
+        "image": "arapulido/ecommerce-spree-discounts:latest",
+        "startTimeout": null,
+        "firelensConfiguration": null,
+        "dependsOn": null,
+        "disableNetworking": null,
+        "interactive": null,
+        "healthCheck": null,
+        "essential": true,
+        "links": [
+          "db"
+        ],
+        "hostname": null,
+        "extraHosts": null,
+        "pseudoTerminal": null,
+        "user": null,
+        "readonlyRootFilesystem": null,
+        "dockerLabels": null,
+        "systemControls": null,
+        "privileged": null,
+        "name": "discounts"
+      },
+      {
+        "dnsSearchDomains": null,
+        "logConfiguration": null,
+        "entryPoint": null,
+        "portMappings": [],
+        "command": null,
+        "linuxParameters": null,
+        "cpu": 0,
+        "environment": [
+          {
+            "name": "POSTGRES_PASSWORD",
+            "value": "<YOUR PASSWORD>"
+          },
+          {
+            "name": "POSTGRES_USER",
+            "value": "postgres"
+          }
+        ],
+        "resourceRequirements": null,
+        "ulimits": null,
+        "dnsServers": null,
+        "mountPoints": [],
+        "workingDirectory": null,
+        "secrets": null,
+        "dockerSecurityOptions": null,
+        "memory": null,
+        "memoryReservation": null,
+        "volumesFrom": [],
+        "stopTimeout": null,
+        "image": "postgres:11-alpine",
+        "startTimeout": null,
+        "firelensConfiguration": null,
+        "dependsOn": null,
+        "disableNetworking": null,
+        "interactive": null,
+        "healthCheck": null,
+        "essential": true,
+        "links": null,
+        "hostname": null,
+        "extraHosts": null,
+        "pseudoTerminal": null,
+        "user": null,
+        "readonlyRootFilesystem": null,
+        "dockerLabels": null,
+        "systemControls": null,
+        "privileged": null,
+        "name": "db"
+      },
+      {
+        "dnsSearchDomains": null,
+        "logConfiguration": null,
+        "entryPoint": null,
+        "portMappings": [
+          {
+            "hostPort": 5002,
+            "protocol": "tcp",
+            "containerPort": 5002
+          }
+        ],
+        "command": [
+          "ddtrace-run",
+          "flask",
+          "run",
+          "--port=5002",
+          "--host=0.0.0.0"
+        ],
+        "linuxParameters": null,
+        "cpu": 0,
+        "environment": [
+          {
+            "name": "DATADOG_SERVICE_NAME",
+            "value": "advertisements-service"
+          },
+          {
+            "name": "DD_AGENT_HOST",
+            "value": "<PRIVATE IP OF THE EC2 INSTANCE>"
+          },
+          {
+            "name": "DD_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_LOGS_INJECTION",
+            "value": "true"
+          },
+          {
+            "name": "FLASK_APP",
+            "value": "ads.py"
+          },
+          {
+            "name": "POSTGRES_PASSWORD",
+            "value": "<YOUR PASSWORD>"
+          },
+          {
+            "name": "POSTGRES_USER",
+            "value": "postgres"
+          }
+        ],
+        "resourceRequirements": null,
+        "ulimits": null,
+        "dnsServers": null,
+        "mountPoints": [],
+        "workingDirectory": null,
+        "secrets": null,
+        "dockerSecurityOptions": null,
+        "memory": null,
+        "memoryReservation": null,
+        "volumesFrom": [],
+        "stopTimeout": null,
+        "image": "arapulido/ecommerce-spree-ads:latest",
+        "startTimeout": null,
+        "firelensConfiguration": null,
+        "dependsOn": null,
+        "disableNetworking": null,
+        "interactive": null,
+        "healthCheck": null,
+        "essential": true,
+        "links": [
+          "db"
+        ],
+        "hostname": null,
+        "extraHosts": null,
+        "pseudoTerminal": null,
+        "user": null,
+        "readonlyRootFilesystem": null,
+        "dockerLabels": null,
+        "systemControls": null,
+        "privileged": null,
+        "name": "advertisements"
+      }
+    ],
+    "placementConstraints": [],
+    "memory": "800",
+    "taskRoleArn": null,
+    "compatibilities": [
+      "EC2"
+    ],
+    "taskDefinitionArn": "<YOUR TASK DEFINITION ARN HERE>",
+    "family": "first-ecommerce-shop",
+    "requiresAttributes": [],
+    "pidMode": null,
+    "requiresCompatibilities": [
+      "EC2"
+    ],
+    "networkMode": null,
+    "cpu": "800",
+    "revision": 14,
+    "status": "ACTIVE",
+    "inferenceAccelerators": null,
+    "proxyConfiguration": null,
+    "volumes": []
+  }

--- a/store-frontend-broken-instrumented/api/config/initializers/datadog.rb
+++ b/store-frontend-broken-instrumented/api/config/initializers/datadog.rb
@@ -3,6 +3,7 @@ Datadog.configure do |c|
   c.use :rails, {'analytics_enabled': true}
   # Make sure requests are also instrumented
   c.use :http, {'analytics_enabled': true}
-  c.tracer hostname: 'agent'
+  # Commented out the hostname so it can be set via environment variable
+  # c.tracer hostname: 'agent'
   c.tracer env: 'ruby-shop'
 end

--- a/store-frontend-broken-instrumented/config/initializers/datadog.rb
+++ b/store-frontend-broken-instrumented/config/initializers/datadog.rb
@@ -1,6 +1,7 @@
 Datadog.configure do |c|
   # This will activate auto-instrumentation for Rails
   c.use :rails
-  c.tracer hostname: 'agent'
+  # Commented out the agent so we can set it with an enviornment variable
+  # c.tracer hostname: 'agent'
   c.tracer env: 'ruby-shop'
 end

--- a/store-frontend-broken-instrumented/frontend/config/initializers/datadog.rb
+++ b/store-frontend-broken-instrumented/frontend/config/initializers/datadog.rb
@@ -1,7 +1,8 @@
 Datadog.configure do |c|
   # This will activate auto-instrumentation for Rails
   c.use :rails
-  c.tracer hostname: 'agent'
+  # commented out hostname so we can set it with an environment variable instead
+  #c.tracer hostname: 'agent'
   c.tracer env: 'ruby-shop'
   c.tracer service: 'shop-frontend'
 end

--- a/store-frontend-instrumented-fixed/config/initializers/datadog.rb
+++ b/store-frontend-instrumented-fixed/config/initializers/datadog.rb
@@ -1,6 +1,7 @@
 Datadog.configure do |c|
   # This will activate auto-instrumentation for Rails
   c.use :rails
-  c.tracer hostname: 'agent'
+  # use environment variable instead for trace hostname
+  #c.tracer hostname: 'agent'
   c.tracer env: 'ruby-shop'
 end

--- a/store-frontend-instrumented-fixed/frontend/config/initializers/datadog.rb
+++ b/store-frontend-instrumented-fixed/frontend/config/initializers/datadog.rb
@@ -1,7 +1,8 @@
 Datadog.configure do |c|
   # This will activate auto-instrumentation for Rails
   c.use :rails
-  c.tracer hostname: 'agent'
+  # commented out hostname, use environment variable instead
+  #c.tracer hostname: 'agent'
   c.tracer env: 'ruby-shop'
   c.tracer service: 'shop-frontend'
 end


### PR DESCRIPTION
This PR fixes hardcoded Agent hostnames in the Docker images for the broken-instrumented and instrumented-fixed directories.

Instead of hardcoding, we can instead set the Agent hostname via the default environment variable, `DD_AGENT_HOST`. This will allow us more flexibility in deploying to diverse environments, such as ECS.

Besides this, it adds an `aws/`  directory, including an example task definition for the Agent Daemon task, and the eCommerce shop. For now, it will only run on ECS on EC2.