### PR TITLE
Updating Frontend Manifest for 1.17+

### DIFF
--- a/k8s-manifests/ecommerce-app/frontend.yaml
+++ b/k8s-manifests/ecommerce-app/frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   labels:

--- a/k8s-manifests/ecommerce-app/frontend.yaml
+++ b/k8s-manifests/ecommerce-app/frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
The "deployment" section of v1, post-beta, has been replaced by "apps". https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

How this affects us: 
In clusters running 1.17 or newer, the old manifest will no longer work, stating that there is no "Deployment" target found in `extensions/v1beta`. This has moved to `v1`, but even changing the version does no address the issues as `deployment` is now under the `apps` umbrella. 