### PR TITLE
Update datadog.rb

### DIFF
--- a/store-frontend-instrumented-fixed/api/config/initializers/datadog.rb
+++ b/store-frontend-instrumented-fixed/api/config/initializers/datadog.rb
@@ -3,6 +3,5 @@ Datadog.configure do |c|
   c.use :rails, {'analytics_enabled': true}
   # Make sure requests are also instrumented
   c.use :http, {'analytics_enabled': true}
-  c.tracer hostname: 'agent'
   c.tracer env: 'ruby-shop'
 end


### PR DESCRIPTION
Hi,

I noticed that traces from frontend were not coming. Taking a look to the logs I found this error:
```
E, [2020-06-15T10:55:54.483953 #7] ERROR -- ddtrace: [ddtrace] (/usr/local/bundle/gems/ddtrace-0.26.0/lib/ddtrace/transport/http/client.rb:46:in `rescue in send_request') Internal error during HTTP transport request. Cause: Failed to open TCP connection to agent:8126 (getaddrinfo: Name or service not known) Location: /usr/local/lib/ruby/2.5.0/net/http.rb:939:in `rescue in block in connect'
Cache read: spree/app_configuration/admin_path
```
It looks that the tracer is trying to send the info to agent:8126, where in the case of k8s it should use DD_AGENT_HOST variable which actually points to host-ip.

I have created this image  jailonso/ecommerce-storefront-instrumented:rum-eu and tested in k8s and it is working ok.



