### PR TITLE
Fixup store-frontend-instrumented build and a few other things

### DIFF
--- a/store-frontend-instrumented-fixed/Dockerfile
+++ b/store-frontend-instrumented-fixed/Dockerfile
@@ -1,16 +1,20 @@
 # This dockerfile is used to build sandbox image for docker clouds. It's not meant to be used in projects
-FROM ruby:2.5.1
-RUN apt-get update -qq && \
-  apt-get install -y build-essential libpq-dev && \
-  curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
+FROM ruby:2.6.6
+RUN apt-get update && apt-get install -y \
+  curl \
+  build-essential \
+  libpq-dev &&\
+  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && apt-get install -y nodejs yarn
 COPY . /spree
 WORKDIR /spree
-RUN bundle install
-RUN bundle update sassc && bundle exec rake store-frontend
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 #COPY ./store-frontend /spree/store-frontend
-RUN cd store-frontend && bundle update sassc
-WORKDIR /spree
 RUN chgrp -R 0 /spree && \
     chmod -R g=u /spree
+RUN cd store-frontend && \
+      bundle install && \
+      yarn install
 CMD ["sh", "docker-entrypoint.sh"]

--- a/store-frontend-instrumented-fixed/docker-entrypoint.sh
+++ b/store-frontend-instrumented-fixed/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This is entrypoint for docker image of spree sandbox on docker cloud
 
-RAILS_ENV=production cd store-frontend && bundle exec rails s -p 3000 -b '0.0.0.0'
+cd store-frontend && RAILS_ENV=development bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/store-frontend-instrumented-fixed/store-frontend/Gemfile
+++ b/store-frontend-instrumented-fixed/store-frontend/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+ruby '2.6.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'

--- a/store-frontend-instrumented-fixed/store-frontend/app/controllers/application_controller.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+  def append_info_to_payload(payload)
+    super
+
+    case
+    when payload[:status] == 200
+      payload[:level] = "INFO"
+    when payload[:status] == 302
+      payload[:level] = "WARN"
+    else
+      payload[:level] = "ERROR"
+    end
+  end
 end

--- a/store-frontend-instrumented-fixed/store-frontend/config/environments/development.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/config/environments/development.rb
@@ -5,31 +5,6 @@ Rails.application.configure do
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-  # Lograge config
-  config.lograge.enabled = true
-
-  # We are asking here to log in RAW (which are actually ruby hashes). The Ruby logging is going to take care of the JSON formatting.
-  config.lograge.formatter = Lograge::Formatters::Json.new
-  config.colorize_logging = false
-  Rails.application.configure do
-    config.lograge.base_controller_class = ['ActionController::API', 'ActionController::Base', 'Spree::Preference', 'Spree::Base', 'Spree::Api::Base', 'Spree::Admin::Base', 'Spree::Core::Base', 'Spree::Preference::Base']
-  end
-
-  # This is useful if you want to log query parameters
-  config.lograge.custom_options = lambda do |event|
-    # Retrieves trace information for current thread
-    correlation = Datadog.tracer.active_correlation
-  
-    {
-      # Adds IDs as tags to log output
-      :dd => {
-        :trace_id => correlation.trace_id,
-        :span_id => correlation.span_id
-      },
-      :ddsource => ["ruby"],
-      :params => event.payload[:params].reject { |k| %w(controller action).include? k }
-    }
-  end
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -77,6 +52,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.log_level = :info
+  config.log_tags = [proc { Datadog.tracer.active_correlation.to_s }]
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
@@ -85,7 +63,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Set the logging destination(s)
-  config.log_to = %w[stdout file]
+  config.log_to = %w[stdout]
 
   # Show the logging configuration on STDOUT
   config.show_log_configuration = true

--- a/store-frontend-instrumented-fixed/store-frontend/config/environments/development.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/config/environments/development.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.web_console.whitelisted_ips = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?

--- a/store-frontend-instrumented-fixed/store-frontend/config/environments/production.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/config/environments/production.rb
@@ -20,35 +20,14 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Lograge config
-  config.lograge.enabled = true
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-
-  # We are asking here to log in RAW (which are actually ruby hashes). The Ruby logging is going to take care of the JSON formatting.
-  config.lograge.formatter = Lograge::Formatters::Json.new
-  config.colorize_logging = false
-  # config.lograge.base_controller_class = ['ActionController::API', 'ActionController::Base', 'Spree::Preference', 'Spree::Base', 'Spree::Api::Base', 'Spree::Admin::Base', 'Spree::Core::Base', 'Spree::Preference::Base']
-  config.lograge.custom_options = lambda do |event|
-    # Retrieves trace information for current thread
-    correlation = Datadog.tracer.active_correlation
-  
-    {
-      # Adds IDs as tags to log output
-      :dd => {
-        :trace_id => correlation.trace_id,
-        :span_id => correlation.span_id
-      },
-      :ddsource => ["ruby"],
-      :params => event.payload[:params].reject { |k| %w(controller action).include? k }
-    }
-  end
   # Compress CSS.
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
+  config.assets.debug = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
@@ -75,7 +54,7 @@ Rails.application.configure do
   config.log_level = :warn
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [proc { Datadog.tracer.active_correlation.to_s }]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/store-frontend-instrumented-fixed/store-frontend/config/initializers/assets.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( discounts.js discounts.css )

--- a/store-frontend-instrumented-fixed/store-frontend/config/initializers/lograge.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/config/initializers/lograge.rb
@@ -1,0 +1,18 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Json.new
+  config.colorize_logging = false
+
+  config.lograge.custom_options = lambda do |event|
+    correlation = Datadog.tracer.active_correlation
+    {
+      dd: {
+        trace_id: correlation.trace_id,
+        span_id: correlation.span_id
+      },
+      ddsource: ["ruby"],
+      params: event.payload[:params].reject { |k| %w(controller action).include? k }
+    }
+  end
+    # config.lograge.base_controller_class = ['ActionController::API', 'ActionController::Base', 'Spree::Preference', 'Spree::Base', 'Spree::Api::Base', 'Spree::Admin::Base', 'Spree::Core::Base', 'Spree::Preference::Base']
+end


### PR DESCRIPTION
This spree-commerce rails app was not properly created to begin with so I am applying generous amounts of duct tape and good intentions until we can safely re-build this from scratch in the storedog folder after things calm down.

I centralized the logging configuration into the lograge initializer and tweaked the default development environment to suppress the cache hit debug messages for now which were the original issue from before. The reason this was never running at top-speed to begin with was the docker-entrypoint trying to pass `RAILS_ENV` to the `cd` command and not the rails boot command. Another discovery is that this _only_ uses Sqlite3 for the database and not Postgres, which I discovered when I got it booting in production mode, only to find it was missing the `production.sqlite3` database file and thus crashed.

## Improvements:

* Upgrade to Ruby 2.6.6 (2.5 is EOL)
* Fixed the Rails environment passing in the docker entrypoint. You can run production, but it's going to be buggy because of how the app was first built. (See my comment in #22 about rebuilding)
* Re-built parts of the Dockerfile in the store-frontend-instrumented-fixed so it's more efficient which cut the build times down from about 300s to around 100s or less. (Y'all should try installing the edge Docker Desktop and put `DOCKER_BUILDKIT=1` in front of the docker build then prepare to be blown away)
* Centralized the logging config in the lograge initializer so it's not spread out across environments.
* Inject the correlation IDs into the logs so they can be attached to traces correctly
* Fixed a small bug with the asset pipeline because certain assets weren't being included