### PR TITLE
modified manifest to serve public to port 80

### DIFF
--- a/k8s-manifests/ecommerce-app/frontend.yaml
+++ b/k8s-manifests/ecommerce-app/frontend.yaml
@@ -69,10 +69,23 @@ metadata:
   name: frontend
 spec:
   ports:
-  - port: 3000
+  - port: 80
     protocol: TCP
     targetPort: 3000
   selector:
     service: frontend
     app: ecommerce
   type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: ecommerce
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000


### PR DESCRIPTION
the frontend.yaml manifest does not contain a public endpoint - the clusterip services internally which means users cannot access the store unless on a private network and accessing it via :3000

this modifies the clusterip to for app to port 80 and then adds a loadbalancer to accept external requests 