### PR TITLE
Animate ads banner with bling bling service for each scenario

### DIFF
--- a/docker-compose-files/docker-compose-broken-instrumented.yml
+++ b/docker-compose-files/docker-compose-broken-instrumented.yml
@@ -79,6 +79,7 @@ services:
     depends_on:
       - agent
       - db
+      - bling-bling
     labels:
       com.datadoghq.ad.logs: '[{"source": "python", "service": "ads-service"}]'
   db:
@@ -89,3 +90,19 @@ services:
       - POSTGRES_USER
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
+  bling-bling:
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_DEBUG=1
+      - DATADOG_SERVICE_NAME=bling-bling-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_ANALYTICS_ENABLED=true
+    image: "ursuladd/bling-bling:latest"
+    command: ddtrace-run flask run --port=5003 --host=0.0.0.0
+    ports:
+      - "5003:5003"
+    depends_on:
+      - agent
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "bling-bling-service"}]'

--- a/docker-compose-files/docker-compose-broken-no-apm-instrumentation.yml
+++ b/docker-compose-files/docker-compose-broken-no-apm-instrumentation.yml
@@ -64,6 +64,7 @@ services:
       - "../ads-service:/app"
     depends_on:
       - agent
+      - bling-bling
       - db
 # add ads log labels
   db:
@@ -74,3 +75,19 @@ services:
       - POSTGRES_USER
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgres", "service": "postgres"}]'
+  bling-bling:
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_DEBUG=1
+      - DATADOG_SERVICE_NAME=bling-bling-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_ANALYTICS_ENABLED=true
+    image: "ursuladd/bling-bling:latest"
+    command: ddtrace-run flask run --port=5003 --host=0.0.0.0
+    ports:
+      - "5003:5003"
+    depends_on:
+      - agent
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "bling-bling-service"}]'

--- a/docker-compose-files/docker-compose-broken-no-instrumentation.yml
+++ b/docker-compose-files/docker-compose-broken-no-instrumentation.yml
@@ -20,6 +20,8 @@ services:
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
+    volumes:
+      - "../store-frontend-broken-instrumented/store-frontend:/spree/store-frontend"
     depends_on:
       - db
       - discounts
@@ -34,7 +36,10 @@ services:
     command: flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"
+    volumes:
+      - "../ads-service:/app"
     depends_on:
+      - bling-bling
       - db
   db:
     image: postgres:11-alpine
@@ -42,3 +47,11 @@ services:
     environment:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
+  bling-bling:
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_DEBUG=1
+    image: "ursuladd/bling-bling:latest"
+    command: flask run --port=5003 --host=0.0.0.0
+    ports:
+      - "5003:5003"

--- a/docker-compose-files/docker-compose-fixed-instrumented-livecode.yml
+++ b/docker-compose-files/docker-compose-fixed-instrumented-livecode.yml
@@ -53,6 +53,8 @@ services:
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
+    volumes:
+      - "../store-frontend-broken-instrumented/store-frontend:/spree/store-frontend"
     depends_on:
       - agent
       - db
@@ -75,8 +77,11 @@ services:
     command: ddtrace-run flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"
+    volumes:
+      - "../ads-service:/app"
     depends_on:
       - agent
+      - bling-bling
       - db
     labels:
       com.datadoghq.ad.logs: '[{"source": "python", "service": "ads-service"}]'
@@ -89,3 +94,19 @@ services:
       - POSTGRES_USER
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
+  bling-bling:
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_DEBUG=1
+      - DATADOG_SERVICE_NAME=bling-bling-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_ANALYTICS_ENABLED=true
+    image: "ursuladd/bling-bling:latest"
+    command: ddtrace-run flask run --port=5003 --host=0.0.0.0
+    ports:
+      - "5003:5003"
+    depends_on:
+      - agent
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "bling-bling-service"}]'

--- a/docker-compose-files/docker-compose-fixed-instrumented.yml
+++ b/docker-compose-files/docker-compose-fixed-instrumented.yml
@@ -51,6 +51,8 @@ services:
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
+    volumes:
+      - "../store-frontend-broken-instrumented/store-frontend:/spree/store-frontend"
     depends_on:
       - agent
       - db
@@ -73,8 +75,11 @@ services:
     command: ddtrace-run flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"
+    volumes:
+      - "../ads-service:/app"
     depends_on:
       - agent
+      - bling-bling
       - db
     labels:
       com.datadoghq.ad.logs: '[{"source": "python", "service": "ads-service"}]'
@@ -87,3 +92,19 @@ services:
       - POSTGRES_USER
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
+  bling-bling:
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_DEBUG=1
+      - DATADOG_SERVICE_NAME=bling-bling-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_ANALYTICS_ENABLED=true
+    image: "ursuladd/bling-bling:latest"
+    command: ddtrace-run flask run --port=5003 --host=0.0.0.0
+    ports:
+      - "5003:5003"
+    depends_on:
+      - agent
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "bling-bling-service"}]'

--- a/store-frontend-broken-instrumented/store-frontend/app/controllers/spree/home_controller.rb
+++ b/store-frontend-broken-instrumented/store-frontend/app/controllers/spree/home_controller.rb
@@ -10,7 +10,7 @@ module Spree
       @taxonomies = Spree::Taxonomy.includes(root: :children)
       @discounts = helpers.get_discounts.sample
       @ads = helpers.get_ads.sample
-      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path']).read).gsub("\n", '')
+      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path'] + "?animated=true").read).gsub("\n", '')
     end
   end
 end

--- a/store-frontend-broken-instrumented/store-frontend/app/controllers/spree/products_controller.rb
+++ b/store-frontend-broken-instrumented/store-frontend/app/controllers/spree/products_controller.rb
@@ -23,7 +23,7 @@ module Spree
       @taxon = params[:taxon_id].present? ? Spree::Taxon.find(params[:taxon_id]) : @product.taxons.first
       redirect_if_legacy_path
       @ads = helpers.get_ads.sample
-      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path']).read).gsub("\n", '')
+      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path'] + "?animated=true").read).gsub("\n", '')
     end
 
     private

--- a/store-frontend-broken-no-instrumentation/store-frontend/app/controllers/spree/home_controller.rb
+++ b/store-frontend-broken-no-instrumentation/store-frontend/app/controllers/spree/home_controller.rb
@@ -10,7 +10,7 @@ module Spree
       @taxonomies = Spree::Taxonomy.includes(root: :children)
       @discounts = helpers.get_discounts.sample
       @ads = helpers.get_ads.sample
-      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path']).read).gsub("\n", '')
+      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path'] + "?animated=true").read).gsub("\n", '')
     end
   end
 end

--- a/store-frontend-broken-no-instrumentation/store-frontend/app/controllers/spree/products_controller.rb
+++ b/store-frontend-broken-no-instrumentation/store-frontend/app/controllers/spree/products_controller.rb
@@ -23,7 +23,7 @@ module Spree
       @taxon = params[:taxon_id].present? ? Spree::Taxon.find(params[:taxon_id]) : @product.taxons.first
       redirect_if_legacy_path
       @ads = helpers.get_ads.sample
-      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path']).read).gsub("\n", '')
+      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path'] + "?animated=true").read).gsub("\n", '')
     end
 
     private

--- a/store-frontend-instrumented-fixed/store-frontend/app/controllers/spree/home_controller.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/app/controllers/spree/home_controller.rb
@@ -10,7 +10,7 @@ module Spree
       @taxonomies = Spree::Taxonomy.includes(root: :children)
       @discounts = helpers.get_discounts.sample
       @ads = helpers.get_ads.sample
-      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path']).read).gsub("\n", '')
+      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path'] + "?animated=true").read).gsub("\n", '')
     end
   end
 end

--- a/store-frontend-instrumented-fixed/store-frontend/app/controllers/spree/products_controller.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/app/controllers/spree/products_controller.rb
@@ -23,7 +23,7 @@ module Spree
       @taxon = params[:taxon_id].present? ? Spree::Taxon.find(params[:taxon_id]) : @product.taxons.first
       redirect_if_legacy_path
       @ads = helpers.get_ads.sample
-      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path']).read).gsub("\n", '')
+      @ads['base64'] = Base64.encode64(open('http://advertisements:5002/banners/' + @ads['path'] + "?animated=true").read).gsub("\n", '')
     end
 
     private


### PR DESCRIPTION
### What does this PR do?
This PR adds the ads banner with flashy blings using the `bling-bling` service when the `animated` query parameter is defined.

### Motivation
Adding a new step in the [`ecommerce-workshop`](https://github.com/DataDog/ecommerce-workshop) for A/B testing a feature.

### Future Work
Testing for [`animated=false`](https://github.com/ursulahuang/ecommerce-workshop/blob/add_bling_bling_to_ads/ads-service/ads.py#L47-L49) (the [original functionality](https://github.com/DataDog/ecommerce-workshop/blob/master/ads-service/ads.py#L25-L26)) hasn't been tested and might raise errors.


