### PR TITLE
Remove sleeps from broken discounts

### DIFF
--- a/discounts-service/discounts.py
+++ b/discounts-service/discounts.py
@@ -29,9 +29,6 @@ def status():
         discounts = Discount.query.all()
         app.logger.info(f"Discounts available: {len(discounts)}")
 
-        # adding a half sleep to test something
-        time.sleep(2.5)
-
         influencer_count = 0
         for discount in discounts:
             if discount.discount_type.influencer:
@@ -49,8 +46,6 @@ def status():
         db.session.commit()
         discounts = Discount.query.all()
 
-        # adding a half sleep to test something
-        time.sleep(2.5)
         return jsonify([b.serialize() for b in discounts])
     else:
         err = jsonify({'error': 'Invalid request method'})


### PR DESCRIPTION
I want to start a discussion about removing the left-over sleeps from the broken discount service.

It made sense when we didn't have the n+1 query, but with the n+1 query, this is enough to see that something is off in the traces. Actually, the sleep hides a bit the issue.

Removing the sleep, leaves a 1 second span mostly used for several postgres queries, which is more visual in my opinion.

![image](https://user-images.githubusercontent.com/925437/96247593-9db9f980-0faa-11eb-9e96-1d5a343b2b92.png)

