### PR TITLE
Deploy cleanup

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,12 +28,10 @@ Look at the `docker-compose` folder README for details.
 * Make sure you have a working `kubectl`, you may need to switch to the platform folder first
 * Run `helm repo add datadog https://helm.datadoghq.com` to track our official HELM repo
 * Run `helm repo update` to sync up the latest chart
-* Create a secret for the API Key `export DATADOG_SECRET_API_KEY_NAME=datadog-api-secret && kubectl create secret generic $DATADOG_SECRET_API_KEY_NAME --from-literal api-key="<DATADOG_API_KEY>" --namespace="default"`
-* If you want to install the Cluster Agent, then export an APP Key `export DATADOG_SECRET_APP_KEY_NAME=datadog-app-secret && kubectl create secret generic $DATADOG_SECRET_APP_KEY_NAME --from-literal app-key="<DATADOG_APP_KEY>" --namespace="default"`
 * Make your own copy of the `helm-values.yaml.example` in the datadog folder `cp datadog/helm-values.yaml.example datadog/helm-values.yaml` and make any changes you would like or just deploy the defaults
-* If you are not installing Cluster Agent, run `helm install datadog-agent --set datadog.apiKeyExistingSecret=<YOUR DATADOG API KEY> --values datadog/helm-values.yaml`
-* If you are installing Cluster Agent, run `helm install datadog-agent datadog/datadog --set datadog.apiKeyExistingSecret=$DATADOG_SECRET_API_KEY_NAME --set datadog.appKeyExistingSecret=$DATADOG_SECRET_APP_KEY_NAME --values datadog/helm-values.yaml`
+* If you are not installing Cluster Agent, run `helm install datadog-agent --set datadog.apiKey=<YOUR DATADOG API KEY> --values datadog/helm-values.yaml`
+* If you are installing Cluster Agent, run `helm install datadog-agent datadog/datadog --set datadog.apiKey=<YOUR DATADOG API KEY> --set datadog.appKey=<YOUR DATADOG APP KEY> --values datadog/helm-values.yaml`
 
 If you ever want to change the values in the chart, you can apply them via a HELM upgrade:
 
-`helm upgrade datadog-agent datadog/datadog --set datadog.apiKeyExistingSecret=$DATADOG_SECRET_API_KEY_NAME --set datadog.appKeyExistingSecret=$DATADOG_SECRET_APP_KEY_NAME --values datadog/helm-values.yaml`
+`helm upgrade datadog-agent datadog/datadog --set datadog.apiKey=<YOUR DATADOG API KEY> --set datadog.appKey=<YOUR DATADOG APP KEY> --values datadog/helm-values.yaml`

--- a/deploy/datadog/helm-values.yaml.example
+++ b/deploy/datadog/helm-values.yaml.example
@@ -1,5 +1,7 @@
 # This is a reasonable set of default HELM settings.
 # Enable/disable as you see fit for your deployment.
+# Tested with version 2.4.31, if your release is 2.5.x or newer, check for
+# changes in the original chart values
 
 # Enable this block if you want to use the newest agent
 # agents:

--- a/deploy/generic-k8s/ecommerce-app/advertisements.yaml
+++ b/deploy/generic-k8s/ecommerce-app/advertisements.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     service: advertisements
     app: ecommerce
+    tags.datadoghq.com/env: "ruby-shop"
   name: advertisements 
 spec:
   replicas: 1
@@ -18,6 +19,7 @@ spec:
       labels:
         service: advertisements
         app: ecommerce
+        tags.datadoghq.com/env: "ruby-shop"
     spec:
       containers:
       - image: ddtraining/advertisements-service:latest
@@ -38,8 +40,10 @@ spec:
             value: "user"
           - name: DATADOG_SERVICE_NAME
             value: "advertisements-service"
-          - name: DD_TAGS
-            value: "env:ruby-shop"
+          - name: DD_ENV
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tags.datadoghq.com/env']
           - name: DD_AGENT_HOST 
             valueFrom:
               fieldRef:

--- a/deploy/generic-k8s/ecommerce-app/discounts.yaml
+++ b/deploy/generic-k8s/ecommerce-app/discounts.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: ecommerce
     service: discounts
+    tags.datadoghq.com/env: "ruby-shop"
   name: discounts
 spec:
   replicas: 1
@@ -18,6 +19,7 @@ spec:
       labels:
         service: discounts
         app: ecommerce
+        tags.datadoghq.com/env: "ruby-shop"
     spec:
       containers:
       - image: ddtraining/discounts-service:latest
@@ -38,7 +40,7 @@ spec:
             value: "user"
           - name: DATADOG_SERVICE_NAME
             value: "discountsservice"
-          - name: DD_AGENT_HOST 
+          - name: DD_AGENT_HOST
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
@@ -46,10 +48,12 @@ spec:
             value: "true"
           - name: DD_ANALYTICS_ENABLED
             value: "true"
-          - name: DD_TAGS
-            value: "env:ruby-shop"
           - name: DD_PROFILING_ENABLED
             value: "true"
+          - name: DD_ENV
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tags.datadoghq.com/env']
         ports:
         - containerPort: 5001
         resources: {}

--- a/deploy/generic-k8s/ecommerce-app/frontend.yaml
+++ b/deploy/generic-k8s/ecommerce-app/frontend.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     service: frontend
     app: ecommerce
+    tags.datadoghq.com/env: "ruby-shop"
   name: frontend
 spec:
   replicas: 1
@@ -21,6 +22,7 @@ spec:
       labels:
         service: frontend
         app: ecommerce
+        tags.datadoghq.com/env: "ruby-shop"
     spec:
       containers:
       - args:
@@ -41,8 +43,10 @@ spec:
               fieldPath: status.hostIP
         - name: DD_LOGS_INJECTION
           value: "true"
-        - name: DD_TAGS
-          value: "env:ruby-shop"
+        - name: DD_ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tags.datadoghq.com/env']
         - name: DD_ANALYTICS_ENABLED
           value: "true"
         # Enable RUM

--- a/deploy/generic-k8s/ecommerce-app/frontend.yaml
+++ b/deploy/generic-k8s/ecommerce-app/frontend.yaml
@@ -82,4 +82,6 @@ spec:
   selector:
     service: frontend
     app: ecommerce
-  type: LoadBalancer
+  # Change this value to LoadBalancer for better public ingress routing to this
+  # pod on most k8s platforms.
+  type: ClusterIP


### PR DESCRIPTION
This is a follow up to #41 with some more tweaks to the documentation and configurations. It does the following:

* Simplifies the Datadog HELM chart instructions
* Switches back to ClusterIP over LoadBalancer for ingress on the frontend (some k8s flavors out there handle this case differently)
* Uses unified tagging to make the generic-k8s experience better out of the box because not all services were using the same tag which made it difficult to work with in APM