### PR TITLE
Initial Github Action for Advertisements

### DIFF
--- a/.github/workflows/advertisements-fixed.yml
+++ b/.github/workflows/advertisements-fixed.yml
@@ -1,0 +1,34 @@
+name: Ads Service (Fixed) Test and Build
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - ads-service-fixed/**
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Versioning Info
+      id: version
+      uses: paulhatch/semantic-version@v3
+      with:
+        namespace: advertisements-fixed
+        change_path: ads-service-fixed
+    - name: Container Registry Login
+      env:
+        MARTINISOFT_TOKEN: ${{ secrets.MARTINISOFT_TOKEN }}
+      run: echo $MARTINISOFT_TOKEN | docker login docker.pkg.github.com -u martinisoft --password-stdin
+    - name: Build the Ads Service (Fixed)
+      run: docker build . --file Dockerfile --tag docker.pkg.github.com/datadog/ecommerce-workshop/advertisements-fixed:latest
+      working-directory: ./ads-service-fixed
+    - name: Publish the Ads Service (Fixed)
+      run: docker push docker.pkg.github.com/datadog/ecommerce-workshop/advertisements-fixed:latest

--- a/.github/workflows/advertisements-fixed.yml
+++ b/.github/workflows/advertisements-fixed.yml
@@ -17,12 +17,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Versioning Info
-      id: version
-      uses: paulhatch/semantic-version@v3
-      with:
-        namespace: advertisements-fixed
-        change_path: ads-service-fixed
     - name: Container Registry Login
       env:
         MARTINISOFT_TOKEN: ${{ secrets.MARTINISOFT_TOKEN }}

--- a/.github/workflows/advertisements.yml
+++ b/.github/workflows/advertisements.yml
@@ -1,0 +1,34 @@
+name: Ads Service Test and Build
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - ads-service/**
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Versioning Info
+      id: version
+      uses: paulhatch/semantic-version@v3
+      with:
+        namespace: advertisements
+        change_path: ads-service
+    - name: Container Registry Login
+      env:
+        MARTINISOFT_TOKEN: ${{ secrets.MARTINISOFT_TOKEN }}
+      run: echo $MARTINISOFT_TOKEN | docker login docker.pkg.github.com -u martinisoft --password-stdin
+    - name: Build the Ads Service
+      run: docker build . --file Dockerfile --tag docker.pkg.github.com/datadog/ecommerce-workshop/advertisements:latest
+      working-directory: ./ads-service
+    - name: Publish the Ads Service
+      run: docker push docker.pkg.github.com/datadog/ecommerce-workshop/advertisements:latest

--- a/.github/workflows/advertisements.yml
+++ b/.github/workflows/advertisements.yml
@@ -17,12 +17,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Versioning Info
-      id: version
-      uses: paulhatch/semantic-version@v3
-      with:
-        namespace: advertisements
-        change_path: ads-service
     - name: Container Registry Login
       env:
         MARTINISOFT_TOKEN: ${{ secrets.MARTINISOFT_TOKEN }}


### PR DESCRIPTION
This is my first pass at a Github action that will build and publish the Advertisements service container to the Github Container Registry. For now, it will publish just a latest tag which we currently do to the Docker Hub registry. We can tackle versioning at another time.

I am putting my own access token here for now until they can support organizational level access tokens for publishing to this repo.

Relates to #47 