### PR TITLE
Cleanup broken symlinks

### DIFF
--- a/store-frontend-broken-no-instrumentation/store-frontend/app/controllers/.#discount_code.rb
+++ b/store-frontend-broken-no-instrumentation/store-frontend/app/controllers/.#discount_code.rb
@@ -1,1 +1,0 @@
-kirk.kaiser@COMP10304.localdomain.24267

--- a/store-frontend-instrumented-fixed/store-frontend/app/controllers/.#discount_code.rb
+++ b/store-frontend-instrumented-fixed/store-frontend/app/controllers/.#discount_code.rb
@@ -1,1 +1,0 @@
-kirk.kaiser@COMP10304.localdomain.24267


### PR DESCRIPTION
These survived the attempted removal in fb8411bd084864938ee3ea7434fcfc304ef346ed

Without removing these, it creates fun file missing errors when cloning/copying the repo like so:

```bash
$ grep -R -a 'discount_code' .
grep: ./store-frontend-instrumented-fixed/store-frontend/app/controllers/.#discount_code.rb: No such file or directory
grep: ./store-frontend-broken-no-instrumentation/store-frontend/app/controllers/.#discount_code.rb: No such file or directory
```

This must be merged before #49 can be considered