### PR TITLE
Upgrade advertisements services

### DIFF
--- a/.github/workflows/advertisements-fixed.yml
+++ b/.github/workflows/advertisements-fixed.yml
@@ -17,12 +17,20 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Container Registry Login
-      env:
-        MARTINISOFT_TOKEN: ${{ secrets.MARTINISOFT_TOKEN }}
-      run: echo $MARTINISOFT_TOKEN | docker login docker.pkg.github.com -u martinisoft --password-stdin
-    - name: Build the Ads Service (Fixed)
-      run: docker build . --file Dockerfile --tag docker.pkg.github.com/datadog/ecommerce-workshop/advertisements-fixed:latest
-      working-directory: ./ads-service-fixed
-    - name: Publish the Ads Service (Fixed)
-      run: docker push docker.pkg.github.com/datadog/ecommerce-workshop/advertisements-fixed:latest
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64 # TODO: Support linux/arm64?
+        push: true
+        tags: ddtraining/advertisements-fixed:latest

--- a/.github/workflows/advertisements.yml
+++ b/.github/workflows/advertisements.yml
@@ -17,12 +17,20 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Container Registry Login
-      env:
-        MARTINISOFT_TOKEN: ${{ secrets.MARTINISOFT_TOKEN }}
-      run: echo $MARTINISOFT_TOKEN | docker login docker.pkg.github.com -u martinisoft --password-stdin
-    - name: Build the Ads Service
-      run: docker build . --file Dockerfile --tag docker.pkg.github.com/datadog/ecommerce-workshop/advertisements:latest
-      working-directory: ./ads-service
-    - name: Publish the Ads Service
-      run: docker push docker.pkg.github.com/datadog/ecommerce-workshop/advertisements:latest
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64 # TODO: Support linux/arm64?
+        push: true
+        tags: ddtraining/advertisements:latest

--- a/ads-service-fixed/Dockerfile
+++ b/ads-service-fixed/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.9.1-alpine3.12
 RUN apk add build-base eudev-dev cython postgresql-dev linux-headers
 COPY requirements.txt /app/requirements.txt
 WORKDIR /app

--- a/ads-service-fixed/requirements.txt
+++ b/ads-service-fixed/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2
-ddtrace==0.44.0
+ddtrace==0.46.0
 Flask==1.1.2
 Flask-SQLAlchemy==2.4.4
 idna==2.10
@@ -11,11 +11,12 @@ Jinja2==2.11.2
 MarkupSafe==1.1.1
 nose==1.3.7
 protobuf==3.14.0
+psycopg2==2.8.6
 Random-Word==1.0.4
-requests==2.25.0
+requests==2.25.1
 six==1.15.0
 sortedcontainers==2.3.0
-SQLAlchemy==1.3.20
+SQLAlchemy==1.3.23
 tenacity==6.2.0
-urllib3==1.26.2
+urllib3==1.26.3
 Werkzeug==1.0.1

--- a/ads-service/Dockerfile
+++ b/ads-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.9.1-alpine3.12
 RUN apk add build-base eudev-dev cython postgresql-dev linux-headers
 COPY requirements.txt /app/requirements.txt
 WORKDIR /app

--- a/ads-service/requirements.txt
+++ b/ads-service/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2
-ddtrace==0.44.0
+ddtrace==0.46.0
 Flask==1.1.2
 Flask-SQLAlchemy==2.4.4
 idna==2.10
@@ -11,11 +11,12 @@ Jinja2==2.11.2
 MarkupSafe==1.1.1
 nose==1.3.7
 protobuf==3.14.0
+psycopg2==2.8.6
 Random-Word==1.0.4
-requests==2.25.0
+requests==2.25.1
 six==1.15.0
 sortedcontainers==2.3.0
-SQLAlchemy==1.3.20
+SQLAlchemy==1.3.23
 tenacity==6.2.0
-urllib3==1.26.2
+urllib3==1.26.3
 Werkzeug==1.0.1


### PR DESCRIPTION
Similar to #63 this upgrades the Python release to latest stable (3.9) while also upgrading the dependencies. Should help with consistency across services to keep all of the python versions closer together.