### PR TITLE
Fix a misunderstanding of context in advertisements publish workflows

### DIFF
--- a/.github/workflows/advertisements-fixed.yml
+++ b/.github/workflows/advertisements-fixed.yml
@@ -29,8 +29,7 @@ jobs:
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v2
       with:
-        context: .
-        file: ./Dockerfile
+        context: ./ads-service-fixed
         platforms: linux/amd64 # TODO: Support linux/arm64?
         push: true
         tags: ddtraining/advertisements-fixed:latest

--- a/.github/workflows/advertisements.yml
+++ b/.github/workflows/advertisements.yml
@@ -29,8 +29,7 @@ jobs:
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v2
       with:
-        context: .
-        file: ./Dockerfile
+        context: ./ads-service
         platforms: linux/amd64 # TODO: Support linux/arm64?
         push: true
         tags: ddtraining/advertisements:latest


### PR DESCRIPTION
This is what I get for reading v1 docs instead of the v2 docs and getting confused. Context is really the folder path where the Dockerfile lives. The file key is for the name of the Dockerfile at that directory or if it lives in another directory. To simplify things, we're going with the default behavior as it would be to build via docker locally where you provide the context where the Dockerfile lives and it figures out the rest.