### PR TITLE
First pass at optimizing builds for advertisements

### DIFF
--- a/ads-service-fixed/.dockerignore
+++ b/ads-service-fixed/.dockerignore
@@ -1,0 +1,37 @@
+# Version control
+.git
+
+# Compiled Python bytecode
+**/__pycache__
+**/*.pyc
+**/*.pyo
+
+# Compiled extensions
+**/*.pyd
+**/*.so
+
+# coverage.py
+.coverage
+.coverage.*
+htmlcov
+
+# Cached files
+.cache
+.mypy_cache
+.hypothesis
+.pytest_cache
+
+# Virtualenvs and builds
+build/
+dist/
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Docker
+Dockerfile*
+.dockerignore

--- a/ads-service-fixed/Dockerfile
+++ b/ads-service-fixed/Dockerfile
@@ -1,6 +1,20 @@
-FROM python:3.9.1-alpine3.12
-RUN apk add build-base eudev-dev cython postgresql-dev linux-headers
-COPY requirements.txt /app/requirements.txt
+# syntax = docker/dockerfile:1.2
+# ^ This enables the new BuildKit stable syntax which can be
+# run with the DOCKER_BUILDKIT=1 environment variable in your
+# docker build command (see build.sh)
+FROM python:3.9.1-slim-buster
+
+# Update, upgrade, and cleanup debian packages
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get upgrade --yes && \
+    apt-get install --yes build-essential libpq-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bring in app
 WORKDIR /app
-ADD . /app
-RUN pip install -r requirements.txt
+COPY . .
+
+# Install dependencies via pip and avoid caching build artifacts
+RUN pip install --no-cache-dir -r requirements.txt

--- a/ads-service-fixed/build.sh
+++ b/ads-service-fixed/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Set bash strict mode so we insta-fail on any errors
+# -e: Exit immediately if a command has non-zero exit code, i.e. fails somehow.
+#      Otherwise bash is like a Python program that just swallows exceptions.
+# -u: Exit with error message if code uses an undefined environment variable,
+#     instead of silently continuing with an empty string.
+# -o pipefail: Like -e, except for piped commands.
+set -euo pipefail
+
+# Enable Docker Buildkit
+export DOCKER_BUILDKIT=1
+
+# Build and tag image
+docker image build --progress=plain --tag ddtraining/advertisements-fixed:latest .

--- a/ads-service/.dockerignore
+++ b/ads-service/.dockerignore
@@ -1,0 +1,37 @@
+# Version control
+.git
+
+# Compiled Python bytecode
+**/__pycache__
+**/*.pyc
+**/*.pyo
+
+# Compiled extensions
+**/*.pyd
+**/*.so
+
+# coverage.py
+.coverage
+.coverage.*
+htmlcov
+
+# Cached files
+.cache
+.mypy_cache
+.hypothesis
+.pytest_cache
+
+# Virtualenvs and builds
+build/
+dist/
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Docker
+Dockerfile*
+.dockerignore

--- a/ads-service/Dockerfile
+++ b/ads-service/Dockerfile
@@ -1,6 +1,20 @@
-FROM python:3.9.1-alpine3.12
-RUN apk add build-base eudev-dev cython postgresql-dev linux-headers
-COPY requirements.txt /app/requirements.txt
+# syntax = docker/dockerfile:1.2
+# ^ This enables the new BuildKit stable syntax which can be
+# run with the DOCKER_BUILDKIT=1 environment variable in your
+# docker build command (see build.sh)
+FROM python:3.9.1-slim-buster
+
+# Update, upgrade, and cleanup debian packages
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get upgrade --yes && \
+    apt-get install --yes build-essential libpq-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bring in app
 WORKDIR /app
-ADD . /app
-RUN pip install -r requirements.txt
+COPY . .
+
+# Install dependencies via pip and avoid caching build artifacts
+RUN pip install --no-cache-dir -r requirements.txt

--- a/ads-service/build.sh
+++ b/ads-service/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Set bash strict mode so we insta-fail on any errors
+# -e: Exit immediately if a command has non-zero exit code, i.e. fails somehow.
+#      Otherwise bash is like a Python program that just swallows exceptions.
+# -u: Exit with error message if code uses an undefined environment variable,
+#     instead of silently continuing with an empty string.
+# -o pipefail: Like -e, except for piped commands.
+set -euo pipefail
+
+# Enable Docker Buildkit
+export DOCKER_BUILDKIT=1
+
+# Build and tag image
+docker image build --progress=plain --tag ddtraining/advertisements:latest .


### PR DESCRIPTION
This does a few things:

* Adds a dockerignore to eliminate extra baggage in the resulting docker
  image
* Adds a `build.sh` script for more easily reproducable builds. Will
  eventually put this into the CI/CD pipeline (and document in README)
* Updates the Dockerfile to use the new BuildKit system in Docker 20.10
  which has been out and stable for some time now
* Changes the base image to Debian Buster (Slim) for easier to find and
  predictable packages. Alpine can be more problematic with certain
  package versions.

Plenty more improvements to come, but this first pass cuts the build
time from about 1 minute 30 seconds down to about 30 seconds with basic
caching. It also cuts the image size down from 525mb to 365mb.

This also _drastically_ speeds up load times (see below) if you run these new images locally via docker-compose. I will eventually swap all of our manifests over to the newer images in a separate PR.

## Running the fixed advertisements service:

![CleanShot 2021-02-16 at 12 49 26](https://user-images.githubusercontent.com/724/108108358-267a9c00-7056-11eb-9f60-b5a66b959343.gif)