### PR TITLE
Storefront service optimization

### DIFF
--- a/store-frontend-broken-instrumented/Dockerfile
+++ b/store-frontend-broken-instrumented/Dockerfile
@@ -1,16 +1,31 @@
-# This dockerfile is used to build sandbox image for docker clouds. It's not meant to be used in projects
-FROM ruby:2.5.1
-RUN apt-get update -qq && \
-  apt-get install -y build-essential libpq-dev && \
-  curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
+# syntax = docker/dockerfile:1.2
+# ^ This enables the new BuildKit stable syntax which can be
+# run with the DOCKER_BUILDKIT=1 environment variable in your
+# docker build command (see build.sh)
+FROM ruby:2.7.2-slim-buster
+
+# Update, upgrade, and cleanup debian packages
+RUN apt-get update && \
+    apt-get upgrade --yes && \
+    apt-get install -y --no-install-recommends curl build-essential git-core libsqlite3-dev libpq-dev && \
+    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y nodejs yarn && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY . /spree
 WORKDIR /spree
-RUN bundle install
-RUN bundle update sassc && bundle exec rake store-frontend
+
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 #COPY ./store-frontend /spree/store-frontend
-RUN cd store-frontend && bundle update sassc
-WORKDIR /spree
 RUN chgrp -R 0 /spree && \
     chmod -R g=u /spree
+
+# Copy in our frontend and run bundle
+RUN cd store-frontend && \
+      bundle install && \
+      yarn install
+
 CMD ["sh", "docker-entrypoint.sh"]

--- a/store-frontend-broken-instrumented/build.sh
+++ b/store-frontend-broken-instrumented/build.sh
@@ -1,53 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+# Set bash strict mode so we insta-fail on any errors
+# -e: Exit immediately if a command has non-zero exit code, i.e. fails somehow.
+#      Otherwise bash is like a Python program that just swallows exceptions.
+# -u: Exit with error message if code uses an undefined environment variable,
+#     instead of silently continuing with an empty string.
+# -o pipefail: Like -e, except for piped commands.
+set -euo pipefail
 
-set -e
+# Enable Docker Buildkit
+export DOCKER_BUILDKIT=1
 
-# Switching Gemfile
-set_gemfile(){
-  echo "Switching Gemfile..."
-  export BUNDLE_GEMFILE="`pwd`/Gemfile"
-}
-
-prepare_app(){
-  set_gemfile
-  bundle update --quiet
-  echo "Preparing test app..."
-  BUNDLE_GEMFILE=../Gemfile bundle exec rake test_app
-}
-# Target postgres. Override with: `DB=sqlite bash build.sh`
-export DB=${DB:-postgres}
-
-# Spree defaults
-echo "Setup Spree defaults..."
-bundle check || bundle update --quiet
-
-# Spree API
-echo "**************************************"
-echo "* Setup Spree API and running RSpec..."
-echo "**************************************"
-cd api; prepare_app; bundle exec rspec spec
-
-# Spree Backend
-echo "******************************************"
-echo "* Setup Spree Backend and running RSpec..."
-echo "******************************************"
-cd ../backend; prepare_app; bundle exec rspec spec
-
-# Spree Core
-echo "***************************************"
-echo "* Setup Spree Core and running RSpec..."
-echo "***************************************"
-cd ../core; prepare_app; bundle exec rspec spec
-
-# Spree Frontend
-echo "*******************************************"
-echo "* Setup Spree Frontend and running RSpec..."
-echo "*******************************************"
-cd ../frontend; prepare_app; bundle exec rspec spec
-
-# Spree Sample
-echo "*****************************************"
-echo "* Setup Spree Sample and running RSpec..."
-echo "*****************************************"
-cd ../sample; prepare_app; bundle exec rspec spec
-
+# Build and tag image
+docker image build --progress=plain --tag ddtraining/storefront:latest .

--- a/store-frontend-broken-instrumented/docker-entrypoint.sh
+++ b/store-frontend-broken-instrumented/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This is entrypoint for docker image of spree sandbox on docker cloud
 
-RAILS_ENV=production cd store-frontend && bundle exec rails s -p 3000 -b '0.0.0.0'
+cd store-frontend && RAILS_ENV=development RUBYOPT='-W0' bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/store-frontend-broken-instrumented/store-frontend/Gemfile
+++ b/store-frontend-broken-instrumented/store-frontend/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
@@ -40,7 +40,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'spree', path: '..'
+gem 'spree', github: 'spree/spree', ref: 'f8e7b4ed9856d1a2f4521f5b8ef7de158a30b398'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 gem 'spree_gateway', github: 'spree/spree_gateway', branch: 'master'
 gem 'ddtrace', '>= 0.4.1'

--- a/store-frontend-broken-instrumented/store-frontend/Gemfile.lock
+++ b/store-frontend-broken-instrumented/store-frontend/Gemfile.lock
@@ -1,26 +1,7 @@
 GIT
-  remote: https://github.com/spree/spree_auth_devise.git
-  revision: 15d74319fa500f14cdc5aabfc8164d5998626303
-  branch: master
-  specs:
-    spree_auth_devise (4.0.0.rc1)
-      deface (~> 1.0)
-      devise (~> 4.7)
-      devise-encryptable (= 0.2.0)
-      spree_core (>= 3.1.0, < 5.0)
-      spree_extension
-
-GIT
-  remote: https://github.com/spree/spree_gateway.git
-  revision: 15f4b907fc7edd3e2f12e2ddde49bb358b823797
-  branch: master
-  specs:
-    spree_gateway (3.6.0)
-      spree_core (>= 3.1.0, < 5.0)
-      spree_extension
-
-PATH
-  remote: ..
+  remote: https://github.com/spree/spree.git
+  revision: f8e7b4ed9856d1a2f4521f5b8ef7de158a30b398
+  ref: f8e7b4ed9856d1a2f4521f5b8ef7de158a30b398
   specs:
     spree (4.0.0.alpha)
       spree_api (= 4.0.0.alpha)
@@ -77,6 +58,27 @@ PATH
     spree_sample (4.0.0.alpha)
       spree_core (= 4.0.0.alpha)
 
+GIT
+  remote: https://github.com/spree/spree_auth_devise.git
+  revision: 15d74319fa500f14cdc5aabfc8164d5998626303
+  branch: master
+  specs:
+    spree_auth_devise (4.0.0.rc1)
+      deface (~> 1.0)
+      devise (~> 4.7)
+      devise-encryptable (= 0.2.0)
+      spree_core (>= 3.1.0, < 5.0)
+      spree_extension
+
+GIT
+  remote: https://github.com/spree/spree_gateway.git
+  revision: 15f4b907fc7edd3e2f12e2ddde49bb358b823797
+  branch: master
+  specs:
+    spree_gateway (3.6.0)
+      spree_core (>= 3.1.0, < 5.0)
+      spree_extension
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -106,7 +108,7 @@ GEM
     activejob (5.2.3)
       activesupport (= 5.2.3)
       globalid (>= 0.3.6)
-    activemerchant (1.97.0)
+    activemerchant (1.119.0)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
@@ -126,16 +128,16 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts-as-taggable-on (6.0.0)
-      activerecord (~> 5.0)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
-    autoprefixer-rails (9.6.1.1)
+    autoprefixer-rails (10.2.4.0)
       execjs
-    awesome_nested_set (3.2.0)
+    awesome_nested_set (3.2.1)
       activerecord (>= 4.0.0, < 7.0)
     awesome_print (1.8.0)
     bcrypt (3.1.13)
@@ -150,16 +152,16 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
     camertron-eprun (1.1.1)
-    cancancan (3.0.1)
-    canonical-rails (0.2.6)
-      rails (>= 4.1, < 6.1)
+    cancancan (3.2.1)
+    canonical-rails (0.2.11)
+      rails (>= 4.1, < 6.2)
     carmen (1.1.3)
       activesupport (>= 3.0.0)
-    cldr-plurals-runtime-rb (1.0.1)
+    cldr-plurals-runtime-rb (1.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    css_parser (1.7.0)
+    css_parser (1.9.0)
       addressable
     ddtrace (0.41.0)
       msgpack
@@ -176,20 +178,20 @@ GEM
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
-    doorkeeper (5.1.0)
+    doorkeeper (5.4.0)
       railties (>= 5)
     erubi (1.8.0)
     execjs (2.7.0)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
-    ffaker (2.12.0)
-    ffi (1.13.1)
+    ffaker (2.17.0)
+    ffi (1.11.1)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     glyphicons (1.0.2)
-    highline (2.0.2)
+    highline (2.0.3)
     htmlentities (4.3.4)
     httparty (0.17.0)
       mime-types (~> 3.0)
@@ -198,7 +200,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -245,29 +247,28 @@ GEM
     mimemagic (0.3.3)
     mini_magick (4.9.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
-    monetize (1.9.2)
+    monetize (1.10.0)
       money (~> 6.12)
-    money (6.13.4)
+    money (6.14.0)
       i18n (>= 0.6.4, <= 2)
     msgpack (1.3.3)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     nio4r (2.5.1)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
-    paranoia (2.4.2)
-      activerecord (>= 4.0, < 6.1)
+    paranoia (2.4.3)
+      activerecord (>= 4.0, < 6.2)
     polyglot (0.3.5)
-    popper_js (1.14.5)
-    premailer (1.11.1)
+    popper_js (1.16.0)
+    premailer (1.14.2)
       addressable
       css_parser (>= 1.6.0)
       htmlentities (>= 4.0.0)
-    premailer-rails (1.10.3)
+    premailer-rails (1.11.1)
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
     pry (0.12.2)
@@ -276,11 +277,10 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (4.0.1)
+    public_suffix (4.0.6)
     puma (3.12.1)
-    rabl (0.14.1)
+    rabl (0.14.3)
       activesupport (>= 2.3.14)
-    racc (1.5.2)
     rack (2.0.7)
     rack-mini-profiler (1.0.2)
       rack (>= 1.2.0)
@@ -359,12 +359,12 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.1)
     state_machines (0.5.0)
-    state_machines-activemodel (0.7.1)
-      activemodel (>= 4.1)
+    state_machines-activemodel (0.8.0)
+      activemodel (>= 5.1)
       state_machines (>= 0.5.0)
-    state_machines-activerecord (0.6.0)
-      activerecord (>= 4.1)
-      state_machines-activemodel (>= 0.5.0)
+    state_machines-activerecord (0.8.0)
+      activerecord (>= 5.1)
+      state_machines-activemodel (>= 0.8.0)
     stringex (2.8.5)
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -414,7 +414,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.7.2p137
 
 BUNDLED WITH
-   1.16.6
+   2.1.4

--- a/store-frontend-instrumented-fixed/Dockerfile
+++ b/store-frontend-instrumented-fixed/Dockerfile
@@ -1,20 +1,31 @@
-# This dockerfile is used to build sandbox image for docker clouds. It's not meant to be used in projects
-FROM ruby:2.6.6
-RUN apt-get update && apt-get install -y \
-  curl \
-  build-essential \
-  libpq-dev &&\
-  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install -y nodejs yarn
+# syntax = docker/dockerfile:1.2
+# ^ This enables the new BuildKit stable syntax which can be
+# run with the DOCKER_BUILDKIT=1 environment variable in your
+# docker build command (see build.sh)
+FROM ruby:2.7.2-slim-buster
+
+# Update, upgrade, and cleanup debian packages
+RUN apt-get update && \
+    apt-get upgrade --yes && \
+    apt-get install -y --no-install-recommends curl build-essential git-core libsqlite3-dev libpq-dev && \
+    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y nodejs yarn && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY . /spree
 WORKDIR /spree
+
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 #COPY ./store-frontend /spree/store-frontend
 RUN chgrp -R 0 /spree && \
     chmod -R g=u /spree
+
+# Copy in our frontend and run bundle
 RUN cd store-frontend && \
       bundle install && \
       yarn install
+
 CMD ["sh", "docker-entrypoint.sh"]

--- a/store-frontend-instrumented-fixed/build.sh
+++ b/store-frontend-instrumented-fixed/build.sh
@@ -1,53 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+# Set bash strict mode so we insta-fail on any errors
+# -e: Exit immediately if a command has non-zero exit code, i.e. fails somehow.
+#      Otherwise bash is like a Python program that just swallows exceptions.
+# -u: Exit with error message if code uses an undefined environment variable,
+#     instead of silently continuing with an empty string.
+# -o pipefail: Like -e, except for piped commands.
+set -euo pipefail
 
-set -e
+# Enable Docker Buildkit
+export DOCKER_BUILDKIT=1
 
-# Switching Gemfile
-set_gemfile(){
-  echo "Switching Gemfile..."
-  export BUNDLE_GEMFILE="`pwd`/Gemfile"
-}
-
-prepare_app(){
-  set_gemfile
-  bundle update --quiet
-  echo "Preparing test app..."
-  BUNDLE_GEMFILE=../Gemfile bundle exec rake test_app
-}
-# Target postgres. Override with: `DB=sqlite bash build.sh`
-export DB=${DB:-postgres}
-
-# Spree defaults
-echo "Setup Spree defaults..."
-bundle check || bundle update --quiet
-
-# Spree API
-echo "**************************************"
-echo "* Setup Spree API and running RSpec..."
-echo "**************************************"
-cd api; prepare_app; bundle exec rspec spec
-
-# Spree Backend
-echo "******************************************"
-echo "* Setup Spree Backend and running RSpec..."
-echo "******************************************"
-cd ../backend; prepare_app; bundle exec rspec spec
-
-# Spree Core
-echo "***************************************"
-echo "* Setup Spree Core and running RSpec..."
-echo "***************************************"
-cd ../core; prepare_app; bundle exec rspec spec
-
-# Spree Frontend
-echo "*******************************************"
-echo "* Setup Spree Frontend and running RSpec..."
-echo "*******************************************"
-cd ../frontend; prepare_app; bundle exec rspec spec
-
-# Spree Sample
-echo "*****************************************"
-echo "* Setup Spree Sample and running RSpec..."
-echo "*****************************************"
-cd ../sample; prepare_app; bundle exec rspec spec
-
+# Build and tag image
+docker image build --progress=plain --tag ddtraining/storefront-fixed:latest .

--- a/store-frontend-instrumented-fixed/docker-entrypoint.sh
+++ b/store-frontend-instrumented-fixed/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This is entrypoint for docker image of spree sandbox on docker cloud
 
-cd store-frontend && RAILS_ENV=development bundle exec rails s -p 3000 -b '0.0.0.0'
+cd store-frontend && RAILS_ENV=development RUBYOPT='-W0' bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/store-frontend-instrumented-fixed/store-frontend/Gemfile
+++ b/store-frontend-instrumented-fixed/store-frontend/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.6'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
@@ -40,7 +40,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'spree', path: '..'
+gem 'spree', github: 'spree/spree', ref: 'f8e7b4ed9856d1a2f4521f5b8ef7de158a30b398'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 gem 'spree_gateway', github: 'spree/spree_gateway', branch: 'master'
 gem 'ddtrace', '>= 0.4.1'

--- a/store-frontend-instrumented-fixed/store-frontend/Gemfile.lock
+++ b/store-frontend-instrumented-fixed/store-frontend/Gemfile.lock
@@ -1,26 +1,7 @@
 GIT
-  remote: https://github.com/spree/spree_auth_devise.git
-  revision: 15d74319fa500f14cdc5aabfc8164d5998626303
-  branch: master
-  specs:
-    spree_auth_devise (4.0.0.rc1)
-      deface (~> 1.0)
-      devise (~> 4.7)
-      devise-encryptable (= 0.2.0)
-      spree_core (>= 3.1.0, < 5.0)
-      spree_extension
-
-GIT
-  remote: https://github.com/spree/spree_gateway.git
-  revision: 15f4b907fc7edd3e2f12e2ddde49bb358b823797
-  branch: master
-  specs:
-    spree_gateway (3.6.0)
-      spree_core (>= 3.1.0, < 5.0)
-      spree_extension
-
-PATH
-  remote: ..
+  remote: https://github.com/spree/spree.git
+  revision: f8e7b4ed9856d1a2f4521f5b8ef7de158a30b398
+  ref: f8e7b4ed9856d1a2f4521f5b8ef7de158a30b398
   specs:
     spree (4.0.0.alpha)
       spree_api (= 4.0.0.alpha)
@@ -77,6 +58,27 @@ PATH
     spree_sample (4.0.0.alpha)
       spree_core (= 4.0.0.alpha)
 
+GIT
+  remote: https://github.com/spree/spree_auth_devise.git
+  revision: 15d74319fa500f14cdc5aabfc8164d5998626303
+  branch: master
+  specs:
+    spree_auth_devise (4.0.0.rc1)
+      deface (~> 1.0)
+      devise (~> 4.7)
+      devise-encryptable (= 0.2.0)
+      spree_core (>= 3.1.0, < 5.0)
+      spree_extension
+
+GIT
+  remote: https://github.com/spree/spree_gateway.git
+  revision: 15f4b907fc7edd3e2f12e2ddde49bb358b823797
+  branch: master
+  specs:
+    spree_gateway (3.6.0)
+      spree_core (>= 3.1.0, < 5.0)
+      spree_extension
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -106,7 +108,7 @@ GEM
     activejob (5.2.3)
       activesupport (= 5.2.3)
       globalid (>= 0.3.6)
-    activemerchant (1.97.0)
+    activemerchant (1.119.0)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
@@ -126,16 +128,16 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts-as-taggable-on (6.0.0)
-      activerecord (~> 5.0)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
-    autoprefixer-rails (9.6.1.1)
+    autoprefixer-rails (10.2.4.0)
       execjs
-    awesome_nested_set (3.2.0)
+    awesome_nested_set (3.2.1)
       activerecord (>= 4.0.0, < 7.0)
     awesome_print (1.8.0)
     bcrypt (3.1.13)
@@ -150,16 +152,16 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
     camertron-eprun (1.1.1)
-    cancancan (3.0.1)
-    canonical-rails (0.2.6)
-      rails (>= 4.1, < 6.1)
+    cancancan (3.2.1)
+    canonical-rails (0.2.11)
+      rails (>= 4.1, < 6.2)
     carmen (1.1.3)
       activesupport (>= 3.0.0)
-    cldr-plurals-runtime-rb (1.0.1)
+    cldr-plurals-runtime-rb (1.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    css_parser (1.7.0)
+    css_parser (1.9.0)
       addressable
     ddtrace (0.41.0)
       msgpack
@@ -176,20 +178,20 @@ GEM
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
-    doorkeeper (5.1.0)
+    doorkeeper (5.4.0)
       railties (>= 5)
     erubi (1.8.0)
     execjs (2.7.0)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
-    ffaker (2.12.0)
+    ffaker (2.17.0)
     ffi (1.11.1)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     glyphicons (1.0.2)
-    highline (2.0.2)
+    highline (2.0.3)
     htmlentities (4.3.4)
     httparty (0.17.0)
       mime-types (~> 3.0)
@@ -198,7 +200,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -247,9 +249,9 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    monetize (1.9.2)
+    monetize (1.10.0)
       money (~> 6.12)
-    money (6.13.4)
+    money (6.14.0)
       i18n (>= 0.6.4, <= 2)
     msgpack (1.3.3)
     multi_json (1.13.1)
@@ -258,15 +260,15 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
-    paranoia (2.4.2)
-      activerecord (>= 4.0, < 6.1)
+    paranoia (2.4.3)
+      activerecord (>= 4.0, < 6.2)
     polyglot (0.3.5)
-    popper_js (1.14.5)
-    premailer (1.11.1)
+    popper_js (1.16.0)
+    premailer (1.14.2)
       addressable
       css_parser (>= 1.6.0)
       htmlentities (>= 4.0.0)
-    premailer-rails (1.10.3)
+    premailer-rails (1.11.1)
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
     pry (0.12.2)
@@ -275,9 +277,9 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (4.0.1)
+    public_suffix (4.0.6)
     puma (3.12.1)
-    rabl (0.14.1)
+    rabl (0.14.3)
       activesupport (>= 2.3.14)
     rack (2.0.7)
     rack-mini-profiler (1.0.2)
@@ -357,12 +359,12 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.1)
     state_machines (0.5.0)
-    state_machines-activemodel (0.7.1)
-      activemodel (>= 4.1)
+    state_machines-activemodel (0.8.0)
+      activemodel (>= 5.1)
       state_machines (>= 0.5.0)
-    state_machines-activerecord (0.6.0)
-      activerecord (>= 4.1)
-      state_machines-activemodel (>= 0.5.0)
+    state_machines-activerecord (0.8.0)
+      activerecord (>= 5.1)
+      state_machines-activemodel (>= 0.8.0)
     stringex (2.8.5)
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -412,7 +414,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.7.2p137
 
 BUNDLED WITH
-   1.16.6
+   2.1.4


### PR DESCRIPTION
This PR is similar to #70 and #67 for optimizing the container builds. I saved the most complex for last of course 😉 

* Cleans up and updates the Dockerfile to upgrade Ruby to 2.7.2 which is the last of the 2.x releases
* Upgrades Bundler to 2.1+ for faster computation of dependencies and installation of them during build/dev time
* Replaces the `build.sh` script with something geared for our project, not theirs
* Replaces the git/directory dependency on Spree and friends to the remote github gem installs which eliminates a lot of startup logging noise that contributes to the issue in #61 and that opens the door to deleting a lot of code and history that doesn't need to be here
* Massively speeds up startup and runtime. First hit will still be the slowest, but once the caching warms up it's crazy fast by comparison.
* Suppresses the Ruby 3.0 deprecation warning spam until we can address those with a Rails/Ruby upgrade later