### PR TITLE
Silence and reformat more logs on the storefront

### DIFF
--- a/store-frontend-broken-instrumented/docker-entrypoint.sh
+++ b/store-frontend-broken-instrumented/docker-entrypoint.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 # This is entrypoint for docker image of spree sandbox on docker cloud
 
-cd store-frontend && RAILS_ENV=development RUBYOPT='-W0' bundle exec rails s -p 3000 -b '0.0.0.0'
+# Set our environment to development for now
+# TODO: Make this more configurable with a default
+export RAILS_ENV=development
+# Silence all Ruby 3.0 deprecation warnings for now until we upgrade
+# TODO: Remove this once we upgrade to Ruby 3.0 and Rails 6.1
+export RUBYOPT='-W0'
+
+cd store-frontend && puma --config config/puma.rb

--- a/store-frontend-instrumented-fixed/docker-entrypoint.sh
+++ b/store-frontend-instrumented-fixed/docker-entrypoint.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 # This is entrypoint for docker image of spree sandbox on docker cloud
 
-cd store-frontend && RAILS_ENV=development RUBYOPT='-W0' bundle exec rails s -p 3000 -b '0.0.0.0'
+# Set our environment to development for now
+# TODO: Make this more configurable with a default
+export RAILS_ENV=development
+# Silence all Ruby 3.0 deprecation warnings for now until we upgrade
+# TODO: Remove this once we upgrade to Ruby 3.0 and Rails 6.1
+export RUBYOPT='-W0'
+
+cd store-frontend && puma --config config/puma.rb


### PR DESCRIPTION
To temporarily support #61 until we can ship a better solution in #80 this PR tweaks a few things in the store-frontend application to silence a lot of the logging noise. Much of it comes from running Rails in development mode which is designed to be very verbose by default, but lograge itself is just as opinionated as rails and strictly only reformats production logging. This ends up creating extremely noisy logs for a student in training or workshops so we will eventually push to a more production-like setup. However, that is a significant amount of work right now and this gets us a temporary solution to help unblock the training team.