### PR TITLE
Upgrade ddtrace on the fixed storefront

### DIFF
--- a/store-frontend-instrumented-fixed/Gemfile.lock
+++ b/store-frontend-instrumented-fixed/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     crass (1.0.6)
     css_parser (1.9.0)
       addressable
-    ddtrace (0.41.0)
+    ddtrace (0.47.0)
       msgpack
     deface (1.5.1)
       nokogiri (>= 1.6)
@@ -241,7 +241,7 @@ GEM
       money (~> 6.12)
     money (6.14.0)
       i18n (>= 0.6.4, <= 2)
-    msgpack (1.3.3)
+    msgpack (1.4.2)
     multi_xml (0.6.0)
     nio4r (2.5.7)
     nokogiri (1.11.2)


### PR DESCRIPTION
This upgrades the ddtracer library to help track down a potential issue with contexts not being generated in logs.

For ref #110 