### PR TITLE
Resolve Rails app logging issue where traces were not being captured

### DIFF
--- a/store-frontend-broken-instrumented/config/environments/development.rb
+++ b/store-frontend-broken-instrumented/config/environments/development.rb
@@ -91,14 +91,16 @@ Rails.application.configure do
   # Add the log tags the way Datadog expects
   config.log_tags = {
     request_id: :request_id,
-    dd: {
-      trace_id: -> { Datadog.tracer.active_correlation.trace_id.to_s },
-      span_id: -> { Datadog.tracer.active_correlation.span_id.to_s },
-      env: -> { Datadog.tracer.active_correlation.env.to_s },
-      service: -> { Datadog.tracer.active_correlation.service.to_s },
-      version: -> { Datadog.tracer.active_correlation.version.to_s }
-    },
-    ddsource: ["ruby"]
+    dd: -> _ {
+      correlation = Datadog.tracer.active_correlation
+      {
+        trace_id: correlation.trace_id.to_s,
+        span_id:  correlation.span_id.to_s,
+        env:      correlation.env.to_s,
+        service:  correlation.service.to_s,
+        version:  correlation.version.to_s
+      }
+    }
   }
 
   # Show the logging configuration on STDOUT

--- a/store-frontend-instrumented-fixed/config/environments/development.rb
+++ b/store-frontend-instrumented-fixed/config/environments/development.rb
@@ -73,7 +73,6 @@ Rails.application.configure do
   config.action_controller.enable_fragment_cache_logging = false
 
   # Set the logging destination(s)
-  config.log_to = %w[stdout file]
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     config.log_to = %w[stdout]
     STDOUT.sync = true
@@ -92,14 +91,16 @@ Rails.application.configure do
   # Add the log tags the way Datadog expects
   config.log_tags = {
     request_id: :request_id,
-    dd: {
-      trace_id: -> { Datadog.tracer.active_correlation.trace_id.to_s },
-      span_id: -> { Datadog.tracer.active_correlation.span_id.to_s },
-      env: -> { Datadog.tracer.active_correlation.env.to_s },
-      service: -> { Datadog.tracer.active_correlation.service.to_s },
-      version: -> { Datadog.tracer.active_correlation.version.to_s }
-    },
-    ddsource: ["ruby"]
+    dd: -> _ {
+      correlation = Datadog.tracer.active_correlation
+      {
+        trace_id: correlation.trace_id.to_s,
+        span_id:  correlation.span_id.to_s,
+        env:      correlation.env.to_s,
+        service:  correlation.service.to_s,
+        version:  correlation.version.to_s
+      }
+    }
   }
 
   # Show the logging configuration on STDOUT


### PR DESCRIPTION
This was a difficult bug to track down. The short answer here is that Semantic Logger's Rack logging adapter will either do a call on a Proc within the log tags or a call on any symbol against the incoming Rack request object. It was difficult to understand this subtle difference, but it solved the problem. My big clue was knowing the datadog tracer was always supposed to return some kind of string, not nil.

Fixes #110 once merged.