### PR TITLE
Flatten out payload in logs on storefront

### DIFF
--- a/store-frontend-broken-instrumented/config/environments/development.rb
+++ b/store-frontend-broken-instrumented/config/environments/development.rb
@@ -69,8 +69,16 @@ Rails.application.configure do
   # Quiet down logger level and disable fragment logging
   config.log_level = :info
   config.colorize_logging = false
-  config.rails_semantic_logger.format = :json
   config.action_controller.enable_fragment_cache_logging = false
+  
+  # Flatten out the payload key for easier parsing
+  payload_formatter = Proc.new do |log, logger|
+    log_hash = log.to_h
+    # The delete method can potentially return nil
+    log_hash.merge!(log_hash.delete(:payload) || {})
+    log_hash.to_json
+  end
+  config.rails_semantic_logger.format = payload_formatter
 
   # Set the logging destination(s)
   if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/store-frontend-broken-instrumented/config/environments/development.rb
+++ b/store-frontend-broken-instrumented/config/environments/development.rb
@@ -70,12 +70,23 @@ Rails.application.configure do
   config.log_level = :info
   config.colorize_logging = false
   config.action_controller.enable_fragment_cache_logging = false
-  
+
   # Flatten out the payload key for easier parsing
   payload_formatter = Proc.new do |log, logger|
     log_hash = log.to_h
     # The delete method can potentially return nil
     log_hash.merge!(log_hash.delete(:payload) || {})
+    # Make sure the log level reflects the HTTP status
+    if log_hash.has_key?(:status)
+      case log_hash[:status]
+      when 200
+        log_hash[:level] = "INFO"
+      when 302
+        log_hash[:level] = "WARN"
+      else
+        log_hash[:level] = "ERROR"
+      end
+    end
     log_hash.to_json
   end
   config.rails_semantic_logger.format = payload_formatter

--- a/store-frontend-instrumented-fixed/config/environments/development.rb
+++ b/store-frontend-instrumented-fixed/config/environments/development.rb
@@ -69,8 +69,15 @@ Rails.application.configure do
   # Quiet down logger level and disable fragment logging
   config.log_level = :info
   config.colorize_logging = false
-  config.rails_semantic_logger.format = :json
   config.action_controller.enable_fragment_cache_logging = false
+
+  # Flatten out the payload key for easier parsing
+  payload_formatter = Proc.new do |log, logger|
+    log_hash = log.to_h
+    log_hash.merge!(log_hash.delete(:payload) || {})
+    log_hash.to_json
+  end
+  config.rails_semantic_logger.format = payload_formatter
 
   # Set the logging destination(s)
   if ENV["RAILS_LOG_TO_STDOUT"].present?


### PR DESCRIPTION
This is a pattern in the new semantic_logger library where a lot of relevant log facets are being wrapped in a payload key inside the JSON log payload which makes it difficult to parse out of the box. By flattening the payload key back into the main structure we can get the default pipeline to work out of the box for us.

We are going from this:

```json
{
  "message": "baz",
  "payload": {
    "path": "/foo",
    "status": 200
  }
}
```

To this:

```json
{
  "message": "baz",
  "path": "/foo",
  "status": 200
}
```

Closes #117 