### PR TITLE
Created new ads-errors image with simple regression patch

### DIFF
--- a/.github/advertisements-errors.yml
+++ b/.github/advertisements-errors.yml
@@ -1,0 +1,35 @@
+name: Ads Service (Errors) Test and Build
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - ads-service-errors/**
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: ./ads-service-errors
+        platforms: linux/amd64 # TODO: Support linux/arm64?
+        push: true
+        tags: ddtraining/advertisements-errors:1.0.0

--- a/ads-service-errors/Dockerfile
+++ b/ads-service-errors/Dockerfile
@@ -1,0 +1,5 @@
+FROM ddtraining/advertisements-fixed:1.0.0
+
+WORKDIR /app
+COPY advertisements.patch .
+RUN patch ads.py advertisements.patch

--- a/ads-service-errors/README.md
+++ b/ads-service-errors/README.md
@@ -1,0 +1,1 @@
+This service will introduce 500 errors when the app attempts to hit the `/ads` endpoint.

--- a/ads-service-errors/advertisements.patch
+++ b/ads-service-errors/advertisements.patch
@@ -1,0 +1,11 @@
+diff -r ads-service-fixed/ads.py ads-service-errors/ads.py
+31d30
+<     advertisements = Advertisement.query.all()
+41d39
+<             advertisements = Advertisement.query.all()
+55d52
+<             advertisements_count = len(Advertisement.query.all())
+62c59
+<             advertisements = Advertisement.query.all()
+---
+>     


### PR DESCRIPTION
This PR introduces a new `ads-service-errors` image which will inherit from `advertisements-fixed:1.0.0` and patch a regression as to not have large amounts of duplicate code in repository.