### PR TITLE
Remove rack mini profiler

### DIFF
--- a/store-frontend-broken-instrumented/Gemfile
+++ b/store-frontend-broken-instrumented/Gemfile
@@ -51,6 +51,5 @@ gem 'rails_semantic_logger'
 group :test, :development do
   gem 'bullet'
   gem 'pry-byebug'
-  gem 'rack-mini-profiler'
   gem 'awesome_print'
 end

--- a/store-frontend-broken-instrumented/Gemfile.lock
+++ b/store-frontend-broken-instrumented/Gemfile.lock
@@ -271,8 +271,6 @@ GEM
       activesupport (>= 2.3.14)
     racc (1.5.2)
     rack (2.2.3)
-    rack-mini-profiler (1.0.2)
-      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.5)
@@ -394,7 +392,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry-byebug
   puma (~> 3.12)
-  rack-mini-profiler
   rails (~> 5.2.5)
   rails_semantic_logger
   sass-rails (~> 5.0)

--- a/store-frontend-instrumented-fixed/Gemfile
+++ b/store-frontend-instrumented-fixed/Gemfile
@@ -51,6 +51,5 @@ gem 'rails_semantic_logger'
 group :test, :development do
   gem 'bullet'
   gem 'pry-byebug'
-  gem 'rack-mini-profiler'
   gem 'awesome_print'
 end

--- a/store-frontend-instrumented-fixed/Gemfile.lock
+++ b/store-frontend-instrumented-fixed/Gemfile.lock
@@ -271,8 +271,6 @@ GEM
       activesupport (>= 2.3.14)
     racc (1.5.2)
     rack (2.2.3)
-    rack-mini-profiler (1.0.2)
-      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.5)
@@ -394,7 +392,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry-byebug
   puma (~> 3.12)
-  rack-mini-profiler
   rails (~> 5.2.5)
   rails_semantic_logger
   sass-rails (~> 5.0)


### PR DESCRIPTION
This drastically slows down the browser rendering and was a leftover from originally forking the spree project. It is normally intended for use in development mode and not production since it adds to the overall rendering time. It will support @obensource in some upcoming courses around frontend projects.