### PR TITLE
Automate tagged releases with documentation

### DIFF
--- a/.github/workflows/advertisements-errors.yml
+++ b/.github/workflows/advertisements-errors.yml
@@ -32,4 +32,4 @@ jobs:
         context: ./ads-service-errors
         platforms: linux/amd64 # TODO: Support linux/arm64?
         push: true
-        tags: ddtraining/advertisements-errors:1.0.0
+        tags: ddtraining/advertisements-errors:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Changelog
 
 # Only release on a new tag that is a version number.
 on:
-  push:
+  create:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
@@ -37,20 +37,20 @@ jobs:
       - name: Download, Tag, and Push Service Images
         run: |
           docker pull ddtraining/advertisements:latest
-          docker tag ddtraining/advertisements:latest ddtraining/advertisements:${{ github.ref }}
-          docker push ddtraining/advertisements:${{ github.ref }}
+          docker tag ddtraining/advertisements:latest ddtraining/advertisements:${{ github.event.ref }}
+          docker push ddtraining/advertisements:${{ github.event.ref }}
           docker pull ddtraining/advertisements-fixed:latest
-          docker tag ddtraining/advertisements-fixed:latest ddtraining/advertisements-fixed:${{ github.ref }}
-          docker push ddtraining/advertisements-fixed:${{ github.ref }}
+          docker tag ddtraining/advertisements-fixed:latest ddtraining/advertisements-fixed:${{ github.event.ref }}
+          docker push ddtraining/advertisements-fixed:${{ github.event.ref }}
           docker pull ddtraining/discounts:latest
-          docker tag ddtraining/discounts:latest ddtraining/discounts:${{ github.ref }}
-          docker push ddtraining/discounts:${{ github.ref }}
+          docker tag ddtraining/discounts:latest ddtraining/discounts:${{ github.event.ref }}
+          docker push ddtraining/discounts:${{ github.event.ref }}
           docker pull ddtraining/discounts-fixed:latest
-          docker tag ddtraining/discounts-fixed:latest ddtraining/discounts-fixed:${{ github.ref }}
-          docker push ddtraining/discounts-fixed:${{ github.ref }}
+          docker tag ddtraining/discounts-fixed:latest ddtraining/discounts-fixed:${{ github.event.ref }}
+          docker push ddtraining/discounts-fixed:${{ github.event.ref }}
           docker pull ddtraining/storefront:latest
-          docker tag ddtraining/storefront:latest ddtraining/storefront:${{ github.ref }}
-          docker push ddtraining/storefront:${{ github.ref }}
+          docker tag ddtraining/storefront:latest ddtraining/storefront:${{ github.event.ref }}
+          docker push ddtraining/storefront:${{ github.event.ref }}
           docker pull ddtraining/storefront-fixed:latest
-          docker tag ddtraining/storefront-fixed:latest ddtraining/storefront-fixed:${{ github.ref }}
-          docker push ddtraining/storefront-fixed:${{ github.ref }}
+          docker tag ddtraining/storefront-fixed:latest ddtraining/storefront-fixed:${{ github.event.ref }}
+          docker push ddtraining/storefront-fixed:${{ github.event.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release Changelog
+
+# Only release on a new tag that is a version number.
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release_a_changelog:
+    name: Release a Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release a Changelog
+        uses: rasmus-saks/release-a-changelog-action@v1.0.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+  publish_service_containers:
+    name: Publish service containers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download, Tag, and Push Service Images
+        run: |
+          docker pull ddtraining/advertisements:latest
+          docker tag ddtraining/advertisements:latest ddtraining/advertisements:${{ github.ref }}
+          docker push ddtraining/advertisements:${{ github.ref }}
+          docker pull ddtraining/advertisements-fixed:latest
+          docker tag ddtraining/advertisements-fixed:latest ddtraining/advertisements-fixed:${{ github.ref }}
+          docker push ddtraining/advertisements-fixed:${{ github.ref }}
+          docker pull ddtraining/discounts:latest
+          docker tag ddtraining/discounts:latest ddtraining/discounts:${{ github.ref }}
+          docker push ddtraining/discounts:${{ github.ref }}
+          docker pull ddtraining/discounts-fixed:latest
+          docker tag ddtraining/discounts-fixed:latest ddtraining/discounts-fixed:${{ github.ref }}
+          docker push ddtraining/discounts-fixed:${{ github.ref }}
+          docker pull ddtraining/storefront:latest
+          docker tag ddtraining/storefront:latest ddtraining/storefront:${{ github.ref }}
+          docker push ddtraining/storefront:${{ github.ref }}
+          docker pull ddtraining/storefront-fixed:latest
+          docker tag ddtraining/storefront-fixed:latest ddtraining/storefront-fixed:${{ github.ref }}
+          docker push ddtraining/storefront-fixed:${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Release a Changelog
         uses: rasmus-saks/release-a-changelog-action@v1.0.1
         with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          github-token: '${{ secrets.GH_TOKEN }}'
   publish_service_containers:
     name: Publish service containers
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a new advertisements-errors image [#123](https://github.com/DataDog/ecommerce-workshop/pull/123)
+- Added DB_HOST support for the python microservices [#128](https://github.com/DataDog/ecommerce-workshop/pull/128)
+- Added availability zone support to the AWS terraform files [#139](https://github.com/DataDog/ecommerce-workshop/pull/139)
+
+### Fixed
+
+- Applied all the latest security updates to storefront service
+- Update all the generic k8s container image names [#137](https://github.com/DataDog/ecommerce-workshop/pull/137)
+
+### Changed
+
+- Remove rack-mini-profiler from both Rails apps [#136](https://github.com/DataDog/ecommerce-workshop/pull/136)
+- Flattened out the logging payload in both Rails apps [#120](https://github.com/DataDog/ecommerce-workshop/pull/120)
+
 ## [1.0.0] - 2021-04-26
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,37 @@
+# Automated version release guide
+
+1. Verify that the CHANGELOG.md unreleased section is accurate and up to date by checking the commits between tags
+1. Update the CHANGELOG.md unrelease section with the next version number. Use [Semver](https://semver.org/) to determine how far to bump things up.
+1. Make a new commit with that changelog using "Release [version]" (e.g. "Release 1.2.3")
+1. Make a new tag with the version number `git tag --annotate 1.0.0 --message="Release 1.0.0"`
+1. Push the new tag `git push && git push --tags`
+1. Monitor the new release workflow in Github Actions which should complete the rest
+
+# Manual version release guide
+
+Note: Replace 1.0.0 with the version number you are releasing
+
+1. Verify that the CHANGELOG.md unreleased section is accurate and up to date by checking the commits between tags
+1. Update the CHANGELOG.md unrelease section with the next version number. Use [Semver](https://semver.org/) to determine how far to bump things up.
+1. Make a new commit with that changelog using "Release 1.0.0"
+1. Make a new tag with the version number `git tag --annotate 1.0.0 --message="Release 1.0.0"`
+1. Push the new tag `git push && git push --tags`
+1. Go to the [tags page](https://github.com/DataDog/ecommerce-workshop/tags) and click the three dots to the right to "Create release". In the prompt, copy and paste the `CHANGELOG.md` notes for the 1.0.0 release in the body and put "1.0.0" for the title.
+1. Pull down the latest advertisements image `docker pull ddtraining/advertisements:latest`
+1. Tag the advertisements latest image with the new version number `docker tag ddtraining/advertisements:latest ddtraining/advertisements:1.0.0`
+1. Push the advertisements image up `docker push ddtraining/advertisements:1.0.0`
+1. Pull down the latest advertisements-fixed image `docker pull ddtraining/advertisements-fixed:latest`
+1. Tag the advertisements latest image with the new version number `docker tag ddtraining/advertisements-fixed:latest ddtraining/advertisements-fixed:1.0.0`
+1. Push the advertisements-fixed image up `docker push ddtraining/advertisements-fixed:1.0.0`
+1. Pull down the latest discounts image `docker pull ddtraining/discounts:latest`
+1. Tag the discounts latest image with the new version number `docker tag ddtraining/discounts:latest ddtraining/discounts:1.0.0`
+1. Push the discounts image up `docker push ddtraining/discounts:1.0.0`
+1. Pull down the latest discounts-fixed image `docker pull ddtraining/discounts-fixed:latest`
+1. Tag the discounts-fixed latest image with the new version number `docker tag ddtraining/discounts-fixed:latest ddtraining/discounts-fixed:1.0.0`
+1. Push the discounts-fixed image up `docker push ddtraining/discounts-fixed:1.0.0`
+1. Pull down the latest storefront image `docker pull ddtraining/storefront:latest`
+1. Tag the storefront latest image with the new version number `docker tag ddtraining/storefront:latest ddtraining/storefront:1.0.0`
+1. Push the storefront image up `docker push ddtraining/storefront:1.0.0`
+1. Pull down the latest storefront-fixed image `docker pull ddtraining/storefront-fixed:latest`
+1. Tag the storefront-fixed latest image with the new version number `docker tag ddtraining/storefront-fixed:latest ddtraining/storefront-fixed:1.0.0`
+1. Push the storefront-fixed image up `docker push ddtraining/storefront-fixed:1.0.0`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,22 +1,25 @@
 # Automated version release guide
 
+**Note:** Replace 1.0.0 with the version number you are releasing
+
 1. Verify that the CHANGELOG.md unreleased section is accurate and up to date by checking the commits between tags
-1. Update the CHANGELOG.md unrelease section with the next version number. Use [Semver](https://semver.org/) to determine how far to bump things up.
-1. Make a new commit with that changelog using "Release [version]" (e.g. "Release 1.2.3")
+1. Update the CHANGELOG.md unreleased section with the next version number. Use [Semver](https://semver.org/) to determine how far to bump things up
+1. Make a new unreleased section at the top. Follow the [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format for this
+1. Make a new commit with that changelog using "Release 1.0.0" as the message
 1. Make a new tag with the version number `git tag --annotate 1.0.0 --message="Release 1.0.0"`
 1. Push the new tag `git push && git push --tags`
 1. Monitor the new release workflow in Github Actions which should complete the rest
 
 # Manual version release guide
 
-Note: Replace 1.0.0 with the version number you are releasing
+**Note:** Replace 1.0.0 with the version number you are releasing
 
 1. Verify that the CHANGELOG.md unreleased section is accurate and up to date by checking the commits between tags
-1. Update the CHANGELOG.md unrelease section with the next version number. Use [Semver](https://semver.org/) to determine how far to bump things up.
+1. Update the CHANGELOG.md unrelease section with the next version number. Use [Semver](https://semver.org/) to determine how far to bump things up
 1. Make a new commit with that changelog using "Release 1.0.0"
 1. Make a new tag with the version number `git tag --annotate 1.0.0 --message="Release 1.0.0"`
 1. Push the new tag `git push && git push --tags`
-1. Go to the [tags page](https://github.com/DataDog/ecommerce-workshop/tags) and click the three dots to the right to "Create release". In the prompt, copy and paste the `CHANGELOG.md` notes for the 1.0.0 release in the body and put "1.0.0" for the title.
+1. Go to the [tags page](https://github.com/DataDog/ecommerce-workshop/tags) and click the three dots to the right to "Create release". In the prompt, copy and paste the `CHANGELOG.md` notes for the 1.0.0 release in the body and put "1.0.0" for the title
 1. Pull down the latest advertisements image `docker pull ddtraining/advertisements:latest`
 1. Tag the advertisements latest image with the new version number `docker tag ddtraining/advertisements:latest ddtraining/advertisements:1.0.0`
 1. Push the advertisements image up `docker push ddtraining/advertisements:1.0.0`


### PR DESCRIPTION
This is an effort to speed up the release cycle by automating a lot of the steps I took manually in #102 which reduces 24 steps into 6. I have done as much testing as I can with this workflow and will be getting another look at it before merge.