### PR TITLE
Build the ads errors image when fixed changes

### DIFF
--- a/.github/workflows/advertisements-errors.yml
+++ b/.github/workflows/advertisements-errors.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     paths:
       - ads-service-errors/**
+      - ads-service-fixed/**
 
 jobs:
 


### PR DESCRIPTION
The ads-error image is just based on a patch for ads-service-fixed, so we need to build it every time ads-service-fixed changes as well, if not we are missing a lot of updates in this image