### PR TITLE
Make 'development' the default environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,16 @@ The scenario uses [GoReplay](https://github.com/buger/goreplay) to spin up traff
 This way, we don't have to manually click around the site to see all the places where our site is broken.
 
 ### Containerized replay
-Example traffic can be perpetually sent via the `traffic-replay` container.  By default this container will send traffic to the host `http://frontend:3000` but can be customized via environment variables.  This facilitates the use of load balancers or breaking apart the application.
+
+Example traffic can be perpetually sent via the `traffic-replay` container. To build and run it via Docker and connect it to your running cluster in docker-compose (by default the docker-compose_default network is created).
+
+```
+cd traffic-replay
+docker build -t traffic-replay .
+docker run -i -t --net=docker-compose_default --rm traffic-replay
+```
+
+By default this container will send traffic to the host `http://frontend:3000` but can be customized via environment variables on the command line or in the below example via Docker Compose.  This facilitates the use of load balancers or breaking apart the application.
 
 ```yaml
 environment:
@@ -76,6 +85,7 @@ environment:
 ```
 
 ### Local replay
+
 You can reuse the recorded traffic ad-hoc:
 
 ```bash

--- a/ads-service-fixed/Dockerfile
+++ b/ads-service-fixed/Dockerfile
@@ -18,3 +18,14 @@ COPY . .
 
 # Install dependencies via pip and avoid caching build artifacts
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Set default Flask app and development environment
+ENV FLASK_APP=ads.py
+ENV DD_ENV=development
+
+# Listen on 5002
+EXPOSE 5002
+
+# Start the app using ddtrace so we have profiling and tracing
+ENTRYPOINT ["ddtrace-run"]
+CMD ["flask", "run", "--port=5002", "--host=0.0.0.0"]

--- a/ads-service-fixed/Dockerfile
+++ b/ads-service-fixed/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.1-slim-buster
+FROM python:3.9.6-slim-buster
 
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/ads-service/Dockerfile
+++ b/ads-service/Dockerfile
@@ -18,3 +18,14 @@ COPY . .
 
 # Install dependencies via pip and avoid caching build artifacts
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Set default Flask app and development environment
+ENV FLASK_APP=ads.py
+ENV DD_ENV=development
+
+# Listen on 5002
+EXPOSE 5002
+
+# Start the app using ddtrace so we have profiling and tracing
+ENTRYPOINT ["ddtrace-run"]
+CMD ["flask", "run", "--port=5002", "--host=0.0.0.0"]

--- a/ads-service/Dockerfile
+++ b/ads-service/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.1-slim-buster
+FROM python:3.9.6-slim-buster
 
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/deploy/aws/ecs/agent-task.json
+++ b/deploy/aws/ecs/agent-task.json
@@ -52,7 +52,7 @@
                 },
                 {
                     "name": "DD_TAGS",
-                    "value": "'env:ruby-shop'"
+                    "value": "'env:development'"
                 },
                 {
                     "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",

--- a/deploy/aws/ecs/shop-task.json
+++ b/deploy/aws/ecs/shop-task.json
@@ -42,7 +42,7 @@
           },
           {
             "name": "DD_ENV",
-            "value": "ruby-shop"
+            "value": "development"
           },
           {
             "name": "DD_LOGS_INJECTION",

--- a/deploy/docker-compose/docker-compose-broken-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-broken-instrumented.yml
@@ -8,7 +8,7 @@ services:
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_PROCESS_AGENT_ENABLED=true
-      - DD_TAGS='env:ruby-shop'
+      - DD_TAGS='env:development'
     ports:
       - "8126:8126"
     volumes:

--- a/deploy/docker-compose/docker-compose-broken-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-broken-instrumented.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   agent:
-    image: "datadog/agent:7.26.0"
+    image: "datadog/agent:7.29.0"
     environment:
       - DD_API_KEY
       - DD_APM_ENABLED=true

--- a/deploy/docker-compose/docker-compose-broken-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-broken-instrumented.yml
@@ -19,7 +19,6 @@ services:
       com.datadoghq.ad.logs: '[{"source": "agent", "service": "agent"}]'
   discounts:
     environment:
-      - FLASK_APP=discounts.py
       - FLASK_DEBUG=1
       - POSTGRES_PASSWORD
       - POSTGRES_USER
@@ -31,7 +30,6 @@ services:
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.0
     image: "ddtraining/discounts:latest"
-    command: ddtrace-run flask run --port=5001 --host=0.0.0.0
     ports:
       - "5001:5001"
     volumes:
@@ -67,7 +65,6 @@ services:
       com.datadoghq.ad.logs: '[{"source": "ruby", "service": "store-frontend"}]'
   advertisements:
     environment:
-      - FLASK_APP=ads.py
       - FLASK_DEBUG=1
       - POSTGRES_PASSWORD
       - POSTGRES_USER
@@ -79,7 +76,6 @@ services:
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.0
     image: "ddtraining/advertisements:latest"
-    command: ddtrace-run flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"
     volumes:
@@ -95,5 +91,6 @@ services:
     environment:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
+      - DD_ENV=development
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'

--- a/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
+++ b/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   agent:
-    image: "datadog/agent:7.26.0"
+    image: "datadog/agent:7.29.0"
     environment:
       - DD_API_KEY
       - DD_PROCESS_AGENT_ENABLED=true

--- a/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
+++ b/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - DD_API_KEY
       - DD_PROCESS_AGENT_ENABLED=true
-      - DD_TAGS='env:ruby-shop'
+      - DD_TAGS='env:development'
 # add agent env variables
 # add agent trace port
     volumes:

--- a/deploy/docker-compose/docker-compose-fixed-instrumented-livecode.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented-livecode.yml
@@ -9,7 +9,7 @@ services:
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_PROCESS_AGENT_ENABLED=true
       - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"team"}
-      - DD_TAGS='env:ruby-shop'
+      - DD_TAGS='env:development'
     ports:
       - "8126:8126"
     volumes:

--- a/deploy/docker-compose/docker-compose-fixed-instrumented-livecode.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented-livecode.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   agent:
-    image: "datadog/agent:7.26.0"
+    image: "datadog/agent:7.29.0"
     environment:
       - DD_API_KEY
       - DD_APM_ENABLED=true

--- a/deploy/docker-compose/docker-compose-fixed-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented.yml
@@ -9,7 +9,7 @@ services:
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_PROCESS_AGENT_ENABLED=true
       - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"team"}
-      - DD_TAGS='env:ruby-shop'
+      - DD_TAGS='env:development'
     ports:
       - "8126:8126"
     volumes:

--- a/deploy/docker-compose/docker-compose-fixed-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   agent:
-    image: "datadog/agent:7.26.0"
+    image: "datadog/agent:7.29.0"
     environment:
       - DD_API_KEY
       - DD_APM_ENABLED=true

--- a/deploy/gcp/gke/datadog-agent.yaml
+++ b/deploy/gcp/gke/datadog-agent.yaml
@@ -48,15 +48,15 @@ spec:
         - name: DD_APM_ENABLED
           value: "true"
         - name: DD_CLUSTER_NAME
-          value: kubernetes-cluster 
+          value: kubernetes-cluster
         - name: DD_KUBELET_TLS_VERIFY
           value: "false"
         - name: DD_LOGS_ENABLED
           value: "true"
         - name: DD_TAGS
-          value: "env:ruby-shop"
+          value: "env:development"
         - name: DD_ENV
-          value: "ruby-shop"
+          value: "development"
         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
           value: "true"
         - name: DD_CRI_SOCKET_PATH

--- a/deploy/generic-k8s/cluster-agent/cluster-agent.yaml
+++ b/deploy/generic-k8s/cluster-agent/cluster-agent.yaml
@@ -52,9 +52,9 @@ spec:
           - name: DD_CLUSTER_NAME
             value: kubernetes-cluster 
           - name: DD_ENV
-            value: "ruby-shop"
+            value: "development"
           - name: DD_TAGS
-            value: "env:ruby-shop"
+            value: "env:development"
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:
               secretKeyRef:

--- a/deploy/generic-k8s/datadog-agent/datadog-agent.yaml
+++ b/deploy/generic-k8s/datadog-agent/datadog-agent.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "datadog"
 type: Opaque
 data:
-  api-key: <replace_with_base64_of_your_api_key> 
+  api-key: <replace_with_base64_of_your_api_key>
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -33,11 +33,11 @@ spec:
             secretKeyRef:
               key: api-key
               name: datadog-secret
-        - name: DD_CLUSTER_AGENT_AUTH_TOKEN 
+        - name: DD_CLUSTER_AGENT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
               key: token
-              name: datadog-auth-token 
+              name: datadog-auth-token
         - name: DD_SITE
           value: datadoghq.com
         - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
@@ -53,15 +53,15 @@ spec:
         - name: DD_APM_ENABLED
           value: "true"
         - name: DD_CLUSTER_NAME
-          value: kubernetes-cluster 
+          value: kubernetes-cluster
         - name: DD_KUBELET_TLS_VERIFY
           value: "false"
         - name: DD_LOGS_ENABLED
           value: "false"
         - name: DD_TAGS
-          value: "env:ruby-shop"
+          value: "env:development"
         - name: DD_ENV
-          value: "ruby-shop"
+          value: "development"
         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
           value: "false"
         - name: DD_CRI_SOCKET_PATH

--- a/deploy/generic-k8s/ecommerce-app/advertisements.yaml
+++ b/deploy/generic-k8s/ecommerce-app/advertisements.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     service: advertisements
     app: ecommerce
-    tags.datadoghq.com/env: "ruby-shop"
+    tags.datadoghq.com/env: "development"
   name: advertisements
 spec:
   replicas: 1
@@ -19,7 +19,7 @@ spec:
       labels:
         service: advertisements
         app: ecommerce
-        tags.datadoghq.com/env: "ruby-shop"
+        tags.datadoghq.com/env: "development"
     spec:
       containers:
       - image: ddtraining/advertisements:latest

--- a/deploy/generic-k8s/ecommerce-app/discounts.yaml
+++ b/deploy/generic-k8s/ecommerce-app/discounts.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: ecommerce
     service: discounts
-    tags.datadoghq.com/env: "ruby-shop"
+    tags.datadoghq.com/env: "development"
   name: discounts
 spec:
   replicas: 1
@@ -19,7 +19,7 @@ spec:
       labels:
         service: discounts
         app: ecommerce
-        tags.datadoghq.com/env: "ruby-shop"
+        tags.datadoghq.com/env: "development"
     spec:
       containers:
       - image: ddtraining/discounts:latest

--- a/deploy/generic-k8s/ecommerce-app/frontend.yaml
+++ b/deploy/generic-k8s/ecommerce-app/frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     service: frontend
     app: ecommerce
-    tags.datadoghq.com/env: "ruby-shop"
+    tags.datadoghq.com/env: "development"
   name: frontend
 spec:
   replicas: 1
@@ -22,7 +22,7 @@ spec:
       labels:
         service: frontend
         app: ecommerce
-        tags.datadoghq.com/env: "ruby-shop"
+        tags.datadoghq.com/env: "development"
     spec:
       containers:
       - args:

--- a/deploy/openshift/cluster-agent/cluster-agent.yaml
+++ b/deploy/openshift/cluster-agent/cluster-agent.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: datadog-cluster-agent
-  namespace: datadog 
+  namespace: datadog
 spec:
   selector:
     matchLabels:
@@ -34,12 +34,12 @@ spec:
           #   valueFrom:
           #     secretKeyRef:
           #       name: datadog-app-key
-          #       key: app-key 
+          #       key: app-key
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"
           - name: DD_LEADER_ELECTION
             value: "true"
-          - name: DD_CLUSTER_CHECKS_ENABLED 
+          - name: DD_CLUSTER_CHECKS_ENABLED
             value: "true"
           # Optional: uncomment to set up External Metrics Provider
           # - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
@@ -50,11 +50,11 @@ spec:
           - name: DD_LOG_LEVEL
             value: 'info'
           - name: DD_CLUSTER_NAME
-            value: kubernetes-cluster 
+            value: kubernetes-cluster
           - name: DD_ENV
-            value: "ruby-shop"
+            value: "development"
           - name: DD_TAGS
-            value: "env:ruby-shop"
+            value: "env:development"
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:
               secretKeyRef:

--- a/deploy/openshift/datadog-agent/datadog-agent.yaml
+++ b/deploy/openshift/datadog-agent/datadog-agent.yaml
@@ -59,9 +59,9 @@ spec:
         - name: DD_LOGS_ENABLED
           value: "false"
         - name: DD_TAGS
-          value: "env:ruby-shop"
+          value: "env:development"
         - name: DD_ENV
-          value: "ruby-shop"
+          value: "development"
         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
           value: "false"
         - name: DD_CRI_SOCKET_PATH

--- a/discounts-service-fixed/Dockerfile
+++ b/discounts-service-fixed/Dockerfile
@@ -18,3 +18,14 @@ COPY . .
 
 # Install dependencies via pip and avoid caching build artifacts
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Let Flask know what to boot
+ENV FLASK_APP=discounts.py
+ENV DD_ENV=development
+
+# Listen on 5001
+EXPOSE 5001
+
+# Start the app using ddtrace so we have profiling and tracing
+ENTRYPOINT ["ddtrace-run"]
+CMD ["flask", "run", "--port=5001", "--host=0.0.0.0"]

--- a/discounts-service-fixed/Dockerfile
+++ b/discounts-service-fixed/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.1-slim-buster
+FROM python:3.9.6-slim-buster
 
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/discounts-service/Dockerfile
+++ b/discounts-service/Dockerfile
@@ -16,8 +16,16 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 WORKDIR /app
 COPY . .
 
-# Let Flask know what to boot
-ENV FLASK_APP=discounts.py
-
 # Install dependencies via pip and avoid caching build artifacts
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Let Flask know what to boot
+ENV FLASK_APP=discounts.py
+ENV DD_ENV=development
+
+# Listen on 5001
+EXPOSE 5001
+
+# Start the app using ddtrace so we have profiling and tracing
+ENTRYPOINT ["ddtrace-run"]
+CMD ["flask", "run", "--port=5001", "--host=0.0.0.0"]

--- a/discounts-service/Dockerfile
+++ b/discounts-service/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.1-slim-buster
+FROM python:3.9.6-slim-buster
 
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/store-frontend-broken-no-instrumentation/api/config/initializers/datadog.rb
+++ b/store-frontend-broken-no-instrumentation/api/config/initializers/datadog.rb
@@ -1,8 +1,0 @@
-Datadog.configure do |c|
-  # This will activate auto-instrumentation for Rails
-  c.use :rails, {'analytics_enabled': true}
-  # Make sure requests are also instrumented
-  c.use :http, {'analytics_enabled': true}
-  c.tracer hostname: 'agent'
-  c.tracer env: 'ruby-shop'
-end

--- a/store-frontend-broken-no-instrumentation/config/initializers/datadog.rb
+++ b/store-frontend-broken-no-instrumentation/config/initializers/datadog.rb
@@ -2,5 +2,4 @@ Datadog.configure do |c|
   # This will activate auto-instrumentation for Rails
   c.use :rails
   c.tracer hostname: 'agent'
-  c.tracer env: 'ruby-shop'
 end

--- a/store-frontend-broken-no-instrumentation/frontend/config/initializers/datadog.rb
+++ b/store-frontend-broken-no-instrumentation/frontend/config/initializers/datadog.rb
@@ -2,6 +2,5 @@ Datadog.configure do |c|
   # This will activate auto-instrumentation for Rails
   c.use :rails
   c.tracer hostname: 'agent'
-  c.tracer env: 'ruby-shop'
   c.tracer service: 'shop-frontend'
 end


### PR DESCRIPTION
To set the goundwork for #9 this pushes all default environments to `development` instead of `ruby-shop` or `none` (the default if Datadog does not detect an environment) which some of the services were doing.

Part of this issue was due to the optimizations we made in the Docker containers and forgot to use default entrypoints and environment variables to set the `DD_ENV` by default. What this ended up doing was making the out-of-box experience with APM a lot more confusing by having two distinct deployment environments. Having the default entrypoints in the containers also reduces a lot of the repetitive commands in all our separate configurations which makes it more difficult to change later. All of this can be over-ridden via Docker or any of the kubernetes configurations so it will remain flexible, just a lot less repetitive.

What this PR does is the following:

* Makes a default environment for the ads and discount services of `development` in the Dockerfile for consistency
* Sets a default entrypoint for both the ads and discount services for consistency (and brevity for all other deployment configs)
* Fixes a gap in the documentation around the starting and building of the traffic container. I plan to make a separate PR to have this container built in CI like the others for easier future deployment
* Cleans up even more excess configuration. Sorry for the noise! ❤️ 
* Upgrades the datadog agent to the 7.29.0 release
* Upgrades the python microservices to Python 3.9.6