### PR TITLE
Allow manual build triggers for Github actions workflows

### DIFF
--- a/.github/workflows/advertisements-errors.yml
+++ b/.github/workflows/advertisements-errors.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - ads-service-errors/**
       - ads-service-fixed/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/advertisements-fixed.yml
+++ b/.github/workflows/advertisements-fixed.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - ads-service-fixed/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/advertisements.yml
+++ b/.github/workflows/advertisements.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - ads-service/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/discounts-fixed.yml
+++ b/.github/workflows/discounts-fixed.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - discounts-service-fixed/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/discounts.yml
+++ b/.github/workflows/discounts.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - discounts-service/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/storefront-fixed.yml
+++ b/.github/workflows/storefront-fixed.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - store-frontend/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/storefront-no-instrumentation.yml
+++ b/.github/workflows/storefront-no-instrumentation.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - store-frontend/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - store-frontend/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/traffic-replay.yml
+++ b/.github/workflows/traffic-replay.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - traffic-replay/**
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
Sometimes is useful to be able to trigger manual builds for certain workflows.

This change allows for that