### PR TITLE
Make traffic-replay env vars overrideable

### DIFF
--- a/deploy/docker-compose/docker-compose-traffic-replay.yml
+++ b/deploy/docker-compose/docker-compose-traffic-replay.yml
@@ -2,4 +2,7 @@ version: '3'
 services:
   traffic-replay:
     image: "ddtraining/traffic-replay:latest"
+    environment:
+      - FRONTEND_HOST
+      - FRONTEND_PORT
 

--- a/traffic-replay/Dockerfile
+++ b/traffic-replay/Dockerfile
@@ -3,5 +3,8 @@ FROM bash:5.1
 RUN wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x /usr/local/bin/wait-for-it.sh
 RUN wget -q -O - https://github.com/buger/goreplay/releases/download/v1.1.0/gor_1.1.0_x64.tar.gz | tar -xz -C /usr/local/bin
 
+ENV FRONTEND_HOST=frontend
+ENV FRONTEND_PORT=3000
+
 COPY requests_0.gor /
-ENTRYPOINT wait-for-it.sh -t 0 ${FRONTEND_HOST:-frontend}:${FRONTEND_PORT:-3000} -s -- gor --input-file-loop --input-file requests_0.gor --output-http "http://${FRONTEND_HOST:-frontend}:${FRONTEND_PORT:-3000}"
+ENTRYPOINT wait-for-it.sh -t 0 ${FRONTEND_HOST}:${FRONTEND_PORT} -s -- gor --input-file-loop --input-file requests_0.gor --output-http "http://${FRONTEND_HOST}:${FRONTEND_PORT}"

--- a/traffic-replay/Dockerfile
+++ b/traffic-replay/Dockerfile
@@ -3,8 +3,5 @@ FROM bash:5.1
 RUN wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x /usr/local/bin/wait-for-it.sh
 RUN wget -q -O - https://github.com/buger/goreplay/releases/download/v1.1.0/gor_1.1.0_x64.tar.gz | tar -xz -C /usr/local/bin
 
-ENV FRONTEND_HOST=frontend
-ENV FRONTEND_PORT=3000
-
 COPY requests_0.gor /
-ENTRYPOINT wait-for-it.sh -t 0 ${FRONTEND_HOST}:${FRONTEND_PORT} -s -- gor --input-file-loop --input-file requests_0.gor --output-http "http://${FRONTEND_HOST}:${FRONTEND_PORT}"
+ENTRYPOINT wait-for-it.sh -t 0 ${FRONTEND_HOST}:${FRONTEND_PORT} -s -- gor --input-file-loop --input-file requests_0.gor --output-http "http://${FRONTEND_HOST:-frontend}:${FRONTEND_PORT:-3000}"

--- a/traffic-replay/Dockerfile
+++ b/traffic-replay/Dockerfile
@@ -4,4 +4,4 @@ RUN wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vish
 RUN wget -q -O - https://github.com/buger/goreplay/releases/download/v1.1.0/gor_1.1.0_x64.tar.gz | tar -xz -C /usr/local/bin
 
 COPY requests_0.gor /
-ENTRYPOINT wait-for-it.sh -t 0 ${FRONTEND_HOST}:${FRONTEND_PORT} -s -- gor --input-file-loop --input-file requests_0.gor --output-http "http://${FRONTEND_HOST:-frontend}:${FRONTEND_PORT:-3000}"
+ENTRYPOINT wait-for-it.sh -t 0 ${FRONTEND_HOST:-frontend}:${FRONTEND_PORT:-3000} -s -- gor --input-file-loop --input-file requests_0.gor --output-http "http://${FRONTEND_HOST:-frontend}:${FRONTEND_PORT:-3000}"


### PR DESCRIPTION
The host and port env vars were not declared in the Dockerfile, and not overrideable.