### PR TITLE
Allow manual trigger of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
   release_a_changelog:


### PR DESCRIPTION
This should allow us to manually run the release workflow via Github UI