### PR TITLE
Manually add tag to images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
-    branches: [ main ]
 
 jobs:
   release_a_changelog:
@@ -38,7 +36,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Download, Tag, and Push Service Images
         run: |
-          TAG=${GITHUB_REF/refs\/tags\//}
+          TAG=2.1.0
           docker pull ddtraining/advertisements:latest
           docker tag ddtraining/advertisements:latest ddtraining/advertisements:$TAG
           docker push ddtraining/advertisements:$TAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
   release_a_changelog:


### PR DESCRIPTION
Running the release workflow manually does not work because it loses reference to the official release tag. I need to hardcode the tag version this one-time, and subsequent new releases should auto-grab the associated tag and work OOTB