### PR TITLE
Pin docker compose images to 2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
-    branches: [ main ]
 
 jobs:
   release_a_changelog:
@@ -38,7 +36,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Download, Tag, and Push Service Images
         run: |
-          TAG=2.1.0
+          TAG=${GITHUB_REF/refs\/tags\//}
           docker pull ddtraining/advertisements:latest
           docker tag ddtraining/advertisements:latest ddtraining/advertisements:$TAG
           docker push ddtraining/advertisements:$TAG
@@ -59,3 +57,4 @@ jobs:
           docker push ddtraining/storefront-fixed:$TAG
           docker pull ddtraining/attackbox:latest
           docker tag ddtraining/attackbox:latest ddtraining/attackbox:$TAG
+          docker push ddtraining/attackbox:$TAG

--- a/attack-box/Dockerfile
+++ b/attack-box/Dockerfile
@@ -37,5 +37,7 @@ RUN chown -R user ./keys
 
 # Switch back to new user so we can SSH properly
 USER user
+RUN chmod 400 /home/user/.ssh/id_rsa
+RUN chmod 400 ./keys/attacker-key
 
 CMD [ "./attack.sh"]

--- a/deploy/docker-compose/docker-compose-broken-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-broken-instrumented.yml
@@ -29,7 +29,7 @@ services:
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.0
-    image: "ddtraining/discounts:latest"
+    image: "ddtraining/discounts:2.1.0"
     ports:
       - "5001:5001"
     volumes:
@@ -50,7 +50,7 @@ services:
       - DB_PASSWORD
       - DD_CLIENT_TOKEN
       - DD_APPLICATION_ID
-    image: "ddtraining/storefront:latest"
+    image: "ddtraining/storefront:2.1.0"
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
@@ -75,7 +75,7 @@ services:
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.0
-    image: "ddtraining/advertisements:latest"
+    image: "ddtraining/advertisements:2.1.0"
     ports:
       - "5002:5002"
     volumes:

--- a/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
+++ b/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
@@ -22,7 +22,7 @@ services:
       - POSTGRES_HOST=db
       - DATADOG_SERVICE_NAME=discounts-service
 # add discounts env variables
-    image: "ddtraining/discounts:latest"
+    image: "ddtraining/discounts:2.1.0"
     command: flask run --port=5001 --host=0.0.0.0
     ports:
       - "5001:5001"
@@ -37,7 +37,7 @@ services:
       - DB_USERNAME
       - DB_PASSWORD
 # add frontend env variables
-    image: "ddtraining/storefront:latest"
+    image: "ddtraining/storefront:2.1.0"
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
@@ -58,7 +58,7 @@ services:
       - POSTGRES_HOST=db
       - DATADOG_SERVICE_NAME=advertisements-service
 # add ads env variables
-    image: "ddtraining/advertisements:latest"
+    image: "ddtraining/advertisements:2.1.0"
     command: flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"

--- a/deploy/docker-compose/docker-compose-broken-no-instrumentation.yml
+++ b/deploy/docker-compose/docker-compose-broken-no-instrumentation.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
       - POSTGRES_HOST=db
-    image: "ddtraining/discounts:latest"
+    image: "ddtraining/discounts:2.1.0"
     command: flask run --port=5001 --host=0.0.0.0
     ports:
       - "5001:5001"
@@ -17,7 +17,7 @@ services:
     environment:
       - DB_USERNAME
       - DB_PASSWORD
-    image: "ddtraining/storefront:latest"
+    image: "ddtraining/storefront:2.1.0"
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
@@ -32,7 +32,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
       - POSTGRES_HOST=db
-    image: "ddtraining/advertisements:latest"
+    image: "ddtraining/advertisements:2.1.0"
     command: flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"

--- a/deploy/docker-compose/docker-compose-fixed-instrumented-attack.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented-attack.yml
@@ -31,8 +31,7 @@ services:
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.1
-    build:
-      context: ../../discounts-service
+    image: "ddtraining/discounts:2.1.0"
     ports:
       - "5001:5001"
       - "22"
@@ -53,7 +52,7 @@ services:
       - DD_VERSION=1.1
       - DD_CLIENT_TOKEN
       - DD_APPLICATION_ID
-    image: "ddtraining/storefront-fixed:latest"
+    image: "ddtraining/storefront-fixed:2.1.0"
     volumes:
       - "../../store-frontend/src/store-frontend-instrumented-fixed:/app"
     command: sh docker-entrypoint.sh
@@ -80,7 +79,7 @@ services:
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.0
-    image: "ddtraining/advertisements-fixed:latest"
+    image: "ddtraining/advertisements-fixed:2.1.0"
     command: ddtrace-run flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"
@@ -99,8 +98,7 @@ services:
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
   attackbox:
-    build:
-      context: ../../attack-box
+    image: "ddtraining/attackbox:2.1.0"
     environment:
       - ATTACK_GOBUSTER
       - ATTACK_HYDRA

--- a/deploy/docker-compose/docker-compose-fixed-instrumented-livecode.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented-livecode.yml
@@ -52,7 +52,7 @@ services:
       - DB_PASSWORD
       - DD_CLIENT_TOKEN
       - DD_APPLICATION_ID
-    image: "ddtraining/storefront-fixed:latest"
+    image: "ddtraining/storefront-fixed:2.1.0"
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
@@ -76,7 +76,7 @@ services:
       - DD_LOGS_INJECTION=true
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
-    image: "ddtraining/advertisements-fixed:latest"
+    image: "ddtraining/advertisements-fixed:2.1.0"
     command: ddtrace-run flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"

--- a/deploy/docker-compose/docker-compose-fixed-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented.yml
@@ -31,7 +31,7 @@ services:
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.1
-    image: "ddtraining/discounts-fixed:latest"
+    image: "ddtraining/discounts-fixed:2.1.0"
     command: ddtrace-run flask run --port=5001 --host=0.0.0.0
     ports:
       - "5001:5001"
@@ -52,7 +52,7 @@ services:
       - DD_VERSION=1.1
       - DD_CLIENT_TOKEN
       - DD_APPLICATION_ID
-    image: "ddtraining/storefront-fixed:latest"
+    image: "ddtraining/storefront-fixed:2.1.0"
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
@@ -77,7 +77,7 @@ services:
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_VERSION=1.0
-    image: "ddtraining/advertisements-fixed:latest"
+    image: "ddtraining/advertisements-fixed:2.1.0"
     command: ddtrace-run flask run --port=5002 --host=0.0.0.0
     ports:
       - "5002:5002"


### PR DESCRIPTION
- Pins all images in `docker-compose` files to latest release 2.1.0
- Add attackbox push command for release workflow

There should be no difference on the katacoda lab end because `latest` and `2.1.0` images should be the same after the `release` workflow was ran

This should resolve #79 