### PR TITLE
Readme update: add info about the destination site

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ Follow the [specific guide for building the images](./development.md#Building)
 
 The `deploy` folder contains the different tested ways in which this application can be deployed.
 
+## Choosing the destination site
+
+You can decide to send metrics, traces and logs either to `datadoghq.com` or `datadoghq.eu`. By default, the data is sent to `datadoghq.com`.
+
+If you want to change the destination, please change the `DD_SITE` value.
+
+For instance, for the Google Kubernetes Engine deployment, edit the file `deploy/gcp/gke/datadog-agent.yaml` and change:
+
+```
+- name: DD_SITE
+  value: datadoghq.com
+```
+
+to:
+
+```
+- name: DD_SITE
+  value: datadoghq.eu
+```
+
 ## Enabling Real User Monitoring (RUM)
 
 Real User Monitoring is enabled for the `docker-compose-fixed-instrumented.yml` docker compose and the Kubernetes `frontend.yaml` deployment.


### PR DESCRIPTION
Hello there,

this PR is related to this issue: https://github.com/DataDog/ecommerce-workshop/issues/177
I updated the Readme file to let users know they can choose the destination site: `datadoghq.com` or `datadoghq.eu`. 

Let me know if I need to update all the files in the deploy folder. I don't think it's necessary but I can do it if needed.