### PR TITLE
fix docker-compose files for lms

### DIFF
--- a/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
+++ b/deploy/docker-compose/docker-compose-broken-no-apm-instrumentation.yml
@@ -38,7 +38,6 @@ services:
       - DB_PASSWORD
 # add frontend env variables
     image: "ddtraining/storefront:2.1.0"
-    command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
     depends_on:
@@ -46,8 +45,6 @@ services:
       - db
       - discounts
       - advertisements
-    volumes:
-      - "../../store-frontend/src/store-frontend-broken-instrumented:/app"
 # add frontend log labels
   advertisements:
     environment:

--- a/deploy/docker-compose/docker-compose-broken-no-instrumentation.yml
+++ b/deploy/docker-compose/docker-compose-broken-no-instrumentation.yml
@@ -18,7 +18,6 @@ services:
       - DB_USERNAME
       - DB_PASSWORD
     image: "ddtraining/storefront:2.1.0"
-    command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
     depends_on:

--- a/deploy/docker-compose/docker-compose-fixed-instrumented-attack.yml
+++ b/deploy/docker-compose/docker-compose-fixed-instrumented-attack.yml
@@ -53,9 +53,6 @@ services:
       - DD_CLIENT_TOKEN
       - DD_APPLICATION_ID
     image: "ddtraining/storefront-fixed:2.1.0"
-    volumes:
-      - "../../store-frontend/src/store-frontend-instrumented-fixed:/app"
-    command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
     depends_on:

--- a/store-frontend/docker-entrypoint.sh
+++ b/store-frontend/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This is entrypoint for docker image of spree sandbox on docker cloud
+
+# Set our environment to development for now
+# TODO: Make this more configurable with a default
+export RAILS_ENV=development
+# Silence all Ruby 3.0 deprecation warnings for now until we upgrade
+# TODO: Remove this once we upgrade to Ruby 3.0 and Rails 6.1
+export RUBYOPT='-W0'
+# Force semantic-logger to report itself as the storefront app
+export SEMANTIC_LOGGER_APP='store-frontend'
+
+puma --config config/puma.rb

--- a/store-frontend/storefront-versions/store-frontend-broken-instrumented/Dockerfile
+++ b/store-frontend/storefront-versions/store-frontend-broken-instrumented/Dockerfile
@@ -20,6 +20,9 @@ COPY ./src/store-frontend-initial-state /app
 COPY ./src/broken-instrumented.patch ./app
 WORKDIR /app
 RUN patch -t -p1 < broken-instrumented.patch
+RUN mkdir -p /opt/storedog
+COPY ./docker-entrypoint.sh /opt/storedog/docker-entrypoint.sh
+RUN chmod +x /opt/storedog/docker-entrypoint.sh
 
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 #COPY ./store-frontend /spree/store-frontend
@@ -33,4 +36,4 @@ RUN bundle install && \
 # Force STDOUT logging
 ENV RAILS_LOG_TO_STDOUT=true
 
-CMD ["sh", "docker-entrypoint.sh"]
+CMD ["sh", "/opt/storedog/docker-entrypoint.sh"]

--- a/store-frontend/storefront-versions/store-frontend-broken-no-instrumentation/Dockerfile
+++ b/store-frontend/storefront-versions/store-frontend-broken-no-instrumentation/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update && \
 
 COPY ./src/store-frontend-initial-state /app
 WORKDIR /app
+RUN mkdir -p /opt/storedog
+COPY ./docker-entrypoint.sh /opt/storedog/docker-entrypoint.sh
+RUN chmod +x /opt/storedog/docker-entrypoint.sh
 
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 #COPY ./store-frontend /spree/store-frontend
@@ -30,4 +33,4 @@ RUN bundle install && \
 # Force STDOUT logging
 ENV RAILS_LOG_TO_STDOUT=true
 
-CMD ["sh", "docker-entrypoint.sh"]
+CMD ["sh", "/opt/storedog/docker-entrypoint.sh"]

--- a/store-frontend/storefront-versions/store-frontend-instrumented-fixed/Dockerfile
+++ b/store-frontend/storefront-versions/store-frontend-instrumented-fixed/Dockerfile
@@ -20,6 +20,9 @@ COPY ./src/store-frontend-initial-state /app
 COPY ./src/instrumented-fixed.patch ./app
 WORKDIR /app
 RUN patch -t -p1 < instrumented-fixed.patch
+RUN mkdir -p /opt/storedog
+COPY ./docker-entrypoint.sh /opt/storedog/docker-entrypoint.sh
+RUN chmod +x /opt/storedog/docker-entrypoint.sh
 
 # COPY ./config/database.yml /spree/sandbox/config/database.yml
 #COPY ./store-frontend /spree/store-frontend
@@ -33,4 +36,4 @@ RUN bundle install && \
 # Force STDOUT logging
 ENV RAILS_LOG_TO_STDOUT=true
 
-CMD ["sh", "docker-entrypoint.sh"]
+CMD ["sh", "/opt/storedog/docker-entrypoint.sh"]


### PR DESCRIPTION
This pull request fixes a problem introduced in 3199fe5725d1f56ee2c24eaf1e43edd411212a27 where patches were added in favor of reducing code duplication.  The docker-compose files formerly leveraged a shared volume with each code set.  Now that the patches are applied to the containers themselves this PR does the following:

Adds an entrypoint outside of the app working directory to `/opt/storedog/`
Removes volume share from the docker-compose itself
Removes explicit command override in favor of letting the container default to the CMD in the Dockerfile

