### PR TITLE
Bump to 2.1.2 for RUM and Session Replay

### DIFF
--- a/deploy/gcp/gke/advertisements.yaml
+++ b/deploy/gcp/gke/advertisements.yaml
@@ -20,7 +20,7 @@ spec:
         app: ecommerce
     spec:
       containers:
-      - image: ddtraining/advertisements:2.1.1
+      - image: ddtraining/advertisements:2.1.2
         name: advertisements 
         command: ["ddtrace-run"]
         args: ["flask", "run", "--port=5002", "--host=0.0.0.0"]

--- a/deploy/gcp/gke/discounts.yaml
+++ b/deploy/gcp/gke/discounts.yaml
@@ -20,7 +20,7 @@ spec:
         app: ecommerce
     spec:
       containers:
-      - image: ddtraining/discounts-fixed:2.1.1
+      - image: ddtraining/discounts-fixed:2.1.2
         name: discounts
         command: ["ddtrace-run"]
         args: ["flask", "run", "--port=5001", "--host=0.0.0.0"]

--- a/deploy/gcp/gke/frontend.yaml
+++ b/deploy/gcp/gke/frontend.yaml
@@ -43,6 +43,12 @@ spec:
           value: "true"
         - name: DD_ANALYTICS_ENABLED
           value: "true"
+        - name: DD_ENV
+          value: "development"
+        - name: DD_SITE
+          value: "datadoghq.com"
+        - name: DD_SERVICE
+          value: "store-frontend"
         # Enable RUM
         #- name: DD_CLIENT_TOKEN
         #  value: ""

--- a/deploy/gcp/gke/frontend.yaml
+++ b/deploy/gcp/gke/frontend.yaml
@@ -48,7 +48,7 @@ spec:
         #  value: ""
         #- name: DD_APPLICATION_ID
         #  value: ""
-        image: ddtraining/storefront-fixed:2.1.1
+        image: ddtraining/storefront-fixed:2.1.2
         imagePullPolicy: Always
         name: ecommerce-spree-observability
         ports:


### PR DESCRIPTION
- Bump GKE images to 2.1.2 to use new RUM package with Session Replay #177 