### PR TITLE
Remove compose volume

### DIFF
--- a/deploy/docker-compose/docker-compose-broken-instrumented.yml
+++ b/deploy/docker-compose/docker-compose-broken-instrumented.yml
@@ -56,8 +56,6 @@ services:
     command: sh docker-entrypoint.sh
     ports:
       - "3000:3000"
-    volumes:
-      - "../../store-frontend/src/store-frontend-broken-instrumented:/app"
     depends_on:
       - agent
       - db


### PR DESCRIPTION
This removes a mount pointing to a patch-generated volume `/store-frontend/src/store-frontend-broken-instrumented` so the compose file `deploy/docker-compose/docker-compose-broken-instrumented.yml` will work OOTB