### PR TITLE
Add M1 mac fix, update attackbox base image

### DIFF
--- a/attackbox/Dockerfile
+++ b/attackbox/Dockerfile
@@ -1,8 +1,8 @@
-FROM kalilinux/kali:latest
+FROM kalilinux/kali-rolling:latest
 RUN mkdir /app
 
 ADD https://github.com/OJ/gobuster/releases/download/v3.1.0/gobuster-linux-amd64.7z /app
-ADD https://github.com/vanhauser-thc/thc-hydra/archive/refs/tags/v9.2.zip /app
+ADD https://github.com/vanhauser-thc/thc-hydra/archive/refs/tags/v9.3.zip /app
 
 # Install packages
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -25,7 +25,7 @@ COPY keys/storedog-leaked-key /home/user/.ssh/id_rsa
 WORKDIR /app
 RUN gzip -d /usr/share/wordlists/rockyou.txt.gz
 RUN 7zr e ./gobuster-linux-amd64.7z && chmod +x gobuster
-RUN unzip v9.2.zip && cd thc-hydra-9.2/ && ./configure && make && make install
+RUN unzip v9.3.zip && cd thc-hydra-9.3/ && ./configure && make && make install
 
 # Copy attack script and keys
 COPY . .

--- a/store-frontend/src/store-frontend-initial-state/config/environments/development.rb
+++ b/store-frontend/src/store-frontend-initial-state/config/environments/development.rb
@@ -64,7 +64,9 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  ## Commenting out this line to fix build for M1 Macs: https://github.com/evilmartians/terraforming-rails/issues/34#issuecomment-872021786
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Quiet down logger level and disable fragment logging
   config.log_level = :info


### PR DESCRIPTION
## Description
We received a report that the frontend image was erroring out on M1 Macs. There is a simple workaround by commenting out a config line in `development.rb`. I tested locally via `docker-compose-local.yml` and the app spins up as expected, and changes are still propagated via the mounted volume.

Separately, when trying to test this locally, I discovered that the base image for attackbox now gives a 404. I've updated it, along with the hydra package, so it should build properly 

## Jira card
https://datadoghq.atlassian.net/browse/WEB-2593