### PR TITLE
fix n+1 query in discounts-fixed

### DIFF
--- a/discounts-service-fixed/discounts.py
+++ b/discounts-service-fixed/discounts.py
@@ -29,7 +29,7 @@ def status():
     if flask_request.method == 'GET':
        
         try:
-          discounts = Discount.query.all()
+          discounts = Discount.query.options(joinedload('*')).all()
           app.logger.info(f"Discounts available: {len(discounts)}")
 
           influencer_count = 0


### PR DESCRIPTION
As part of this PR: https://github.com/DataDog/ecommerce-workshop/pull/197  it was removed the line that fixes the n+1 query in the discounts-fixed version of discounts. So both the broken version and the fixed versions had the same issue.

This PR re-adds the fix so those two images are different.